### PR TITLE
Bugfix/no links provided for collection search when empty

### DIFF
--- a/stac_fastapi/core/stac_fastapi/core/core.py
+++ b/stac_fastapi/core/stac_fastapi/core/core.py
@@ -1014,12 +1014,16 @@ class EsAsyncCollectionSearchClient(AsyncCollectionSearchClient):
             )
         )
 
-        collections = [
-            self.collection_serializer.db_to_stac(collection, base_url=base_url)
-            for collection in collections
+        links = [
+            {"rel": Relations.root.value, "type": MimeTypes.json, "href": base_url},
+            {"rel": Relations.parent.value, "type": MimeTypes.json, "href": base_url},
+            {
+                "rel": Relations.self.value,
+                "type": MimeTypes.json,
+                "href": urljoin(base_url, "collections"),
+            },
         ]
 
-        links = []
         if next_token:
             links = await PagingLinks(request=request, next=next_token).get_links()
 

--- a/stac_fastapi/core/stac_fastapi/core/core.py
+++ b/stac_fastapi/core/stac_fastapi/core/core.py
@@ -225,10 +225,6 @@ class CoreClient(AsyncBaseCoreClient):
             next_link = PagingLinks(next=next_token, request=request).link_next()
             links.append(next_link)
 
-        print("all_collections")
-        print(type(collections))
-        print(collections)
-
         return Collections(collections=collections, links=links)
 
     async def get_collection(self, collection_id: str, **kwargs) -> Collection:
@@ -1031,10 +1027,6 @@ class EsAsyncCollectionSearchClient(AsyncCollectionSearchClient):
         if next_token:
             links = await PagingLinks(request=request, next=next_token).get_links()
 
-        print("returning collections now")
-        print("collection search")
-        print(type(collections))
-        print(collections)
         return Collections(collections=collections, links=links)
 
     # todo: use the ES _mapping endpoint to dynamically find what fields exist

--- a/stac_fastapi/core/stac_fastapi/core/core.py
+++ b/stac_fastapi/core/stac_fastapi/core/core.py
@@ -225,6 +225,10 @@ class CoreClient(AsyncBaseCoreClient):
             next_link = PagingLinks(next=next_token, request=request).link_next()
             links.append(next_link)
 
+        print("all_collections")
+        print(type(collections))
+        print(collections)
+
         return Collections(collections=collections, links=links)
 
     async def get_collection(self, collection_id: str, **kwargs) -> Collection:
@@ -1027,6 +1031,10 @@ class EsAsyncCollectionSearchClient(AsyncCollectionSearchClient):
         if next_token:
             links = await PagingLinks(request=request, next=next_token).get_links()
 
+        print("returning collections now")
+        print("collection search")
+        print(type(collections))
+        print(collections)
         return Collections(collections=collections, links=links)
 
     # todo: use the ES _mapping endpoint to dynamically find what fields exist

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
@@ -882,7 +882,12 @@ class DatabaseLogic:
             raise NotFoundError(f"Collections '{collection_ids}' do not exist")
 
         hits = es_response["hits"]["hits"]
-        collections = (hit["_source"] for hit in hits)
+        collections = [
+            self.collection_serializer.db_to_stac(
+                collection=hit["_source"], base_url=base_url
+            )
+            for hit in hits
+        ]
 
         next_token = None
         if hits and (sort_array := hits[-1].get("sort")):

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
@@ -881,7 +881,6 @@ class DatabaseLogic:
         except exceptions.NotFoundError:
             raise NotFoundError(f"Collections '{collection_ids}' do not exist")
 
-        print("about to serialise outputs")
         hits = es_response["hits"]["hits"]
         collections = [
             self.collection_serializer.db_to_stac(
@@ -889,7 +888,6 @@ class DatabaseLogic:
             )
             for hit in hits
         ]
-        print("result serialised")
 
         next_token = None
         if hits and (sort_array := hits[-1].get("sort")):

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
@@ -149,7 +149,7 @@ ES_COLLECTIONS_MAPPINGS = {
     "runtime": {
         "collection_start_time": {
             "type": "date",
-            "on_script_error": "fail",
+            "on_script_error": "continue",
             "script": {
                 "source": """
                 def times = params._source.extent.temporal.interval; 
@@ -166,7 +166,7 @@ ES_COLLECTIONS_MAPPINGS = {
         },
         "collection_end_time": {
             "type": "date",
-            "on_script_error": "fail",
+            "on_script_error": "continue",
             "script": {
                 "source": """
                 def times = params._source.extent.temporal.interval; 
@@ -183,33 +183,33 @@ ES_COLLECTIONS_MAPPINGS = {
         },
         "geometry.shape": {
             "type": "keyword",
-            "on_script_error": "fail",
+            "on_script_error": "continue",
             "script": {"source": "emit('Polygon')"},
         },
         "collection_min_lat": {
             "type": "double",
-            "on_script_error": "fail",
+            "on_script_error": "continue",
             "script": {
                 "source": "def bbox = params._source.extent.spatial.bbox; emit(bbox[0][0]);"
             },
         },
         "collection_min_lon": {
             "type": "double",
-            "on_script_error": "fail",
+            "on_script_error": "continue",
             "script": {
                 "source": "def bbox = params._source.extent.spatial.bbox; emit(bbox[0][1]);"
             },
         },
         "collection_max_lat": {
             "type": "double",
-            "on_script_error": "fail",
+            "on_script_error": "continue",
             "script": {
                 "source": "def bbox = params._source.extent.spatial.bbox; emit(bbox[0][2]);"
             },
         },
         "collection_max_lon": {
             "type": "double",
-            "on_script_error": "fail",
+            "on_script_error": "continue",
             "script": {
                 "source": "def bbox = params._source.extent.spatial.bbox; emit(bbox[0][3]);"
             },
@@ -881,6 +881,7 @@ class DatabaseLogic:
         except exceptions.NotFoundError:
             raise NotFoundError(f"Collections '{collection_ids}' do not exist")
 
+        print("about to serialise outputs")
         hits = es_response["hits"]["hits"]
         collections = [
             self.collection_serializer.db_to_stac(
@@ -888,6 +889,7 @@ class DatabaseLogic:
             )
             for hit in hits
         ]
+        print("result serialised")
 
         next_token = None
         if hits and (sort_array := hits[-1].get("sort")):


### PR DESCRIPTION
- Reformatted code to better match previous `get_collections` method
- Ensured links are returned when search results themselves are blank.