### PR TITLE
Bugfix/eodhp 298 stac fastapi self and next links

### DIFF
--- a/stac_fastapi/core/stac_fastapi/core/core.py
+++ b/stac_fastapi/core/stac_fastapi/core/core.py
@@ -222,7 +222,7 @@ class CoreClient(AsyncBaseCoreClient):
         ]
 
         if next_token:
-            next_link = PagingLinks(next=next_token, request=request).link_next()
+            next_link = await PagingLinks(next=next_token, request=request).link_next()
             links.append(next_link)
 
         return Collections(collections=collections, links=links)
@@ -1001,8 +1001,6 @@ class EsAsyncCollectionSearchClient(AsyncCollectionSearchClient):
         if search_request.limit:
             limit = search_request.limit
 
-        base_url = str(request.base_url)
-
         collections, maybe_count, next_token = (
             await self.database.execute_collection_search(
                 search=search,
@@ -1013,6 +1011,8 @@ class EsAsyncCollectionSearchClient(AsyncCollectionSearchClient):
                 base_url=base_url,
             )
         )
+
+        print(base_url)
 
         links = [
             {"rel": Relations.root.value, "type": MimeTypes.json, "href": base_url},

--- a/stac_fastapi/core/stac_fastapi/core/core.py
+++ b/stac_fastapi/core/stac_fastapi/core/core.py
@@ -1016,7 +1016,7 @@ class EsAsyncCollectionSearchClient(AsyncCollectionSearchClient):
 
         links = [
             {"rel": Relations.root.value, "type": MimeTypes.json, "href": base_url},
-            {"rel": Relations.parent.value, "type": MimeTypes.json, "href": base_url},
+            {"rel": Relations.parent.value, "type": MimeTypes.json, "href": "testingvalue"},
             {
                 "rel": Relations.self.value,
                 "type": MimeTypes.json,
@@ -1025,6 +1025,7 @@ class EsAsyncCollectionSearchClient(AsyncCollectionSearchClient):
         ]
 
         if next_token:
+            print("calculating next link")
             next_link = PagingLinks(next=next_token, request=request).link_next()
             links.append(next_link)
 

--- a/stac_fastapi/core/stac_fastapi/core/core.py
+++ b/stac_fastapi/core/stac_fastapi/core/core.py
@@ -1012,23 +1012,6 @@ class EsAsyncCollectionSearchClient(AsyncCollectionSearchClient):
             )
         )
 
-        print(base_url)
-
-        links = [
-            {"rel": Relations.root.value, "type": MimeTypes.json, "href": base_url},
-            {"rel": Relations.parent.value, "type": MimeTypes.json, "href": base_url},
-            {
-                "rel": Relations.self.value,
-                "type": MimeTypes.json,
-                "href": urljoin(base_url, "collections"),
-            },
-        ]
-
-        # if next_token:
-        #     print("calculating next link")
-        #     next_link = PagingLinks(next=next_token, request=request).link_next()
-        #     links.append(next_link)
-
         links = []
         if next_token:
             links = await PagingLinks(request=request, next=next_token).get_links()

--- a/stac_fastapi/core/stac_fastapi/core/core.py
+++ b/stac_fastapi/core/stac_fastapi/core/core.py
@@ -222,7 +222,7 @@ class CoreClient(AsyncBaseCoreClient):
         ]
 
         if next_token:
-            next_link = await PagingLinks(next=next_token, request=request).link_next()
+            next_link = PagingLinks(next=next_token, request=request).link_next()
             links.append(next_link)
 
         return Collections(collections=collections, links=links)

--- a/stac_fastapi/core/stac_fastapi/core/core.py
+++ b/stac_fastapi/core/stac_fastapi/core/core.py
@@ -1025,7 +1025,8 @@ class EsAsyncCollectionSearchClient(AsyncCollectionSearchClient):
         ]
 
         if next_token:
-            links = await PagingLinks(request=request, next=next_token).get_links()
+            next_link = PagingLinks(next=next_token, request=request).link_next()
+            links.append(next_link)
 
         return Collections(collections=collections, links=links)
 

--- a/stac_fastapi/core/stac_fastapi/core/core.py
+++ b/stac_fastapi/core/stac_fastapi/core/core.py
@@ -1016,7 +1016,7 @@ class EsAsyncCollectionSearchClient(AsyncCollectionSearchClient):
 
         links = [
             {"rel": Relations.root.value, "type": MimeTypes.json, "href": base_url},
-            {"rel": Relations.parent.value, "type": MimeTypes.json, "href": "testingvalue"},
+            {"rel": Relations.parent.value, "type": MimeTypes.json, "href": base_url},
             {
                 "rel": Relations.self.value,
                 "type": MimeTypes.json,

--- a/stac_fastapi/core/stac_fastapi/core/core.py
+++ b/stac_fastapi/core/stac_fastapi/core/core.py
@@ -1024,10 +1024,14 @@ class EsAsyncCollectionSearchClient(AsyncCollectionSearchClient):
             },
         ]
 
+        # if next_token:
+        #     print("calculating next link")
+        #     next_link = PagingLinks(next=next_token, request=request).link_next()
+        #     links.append(next_link)
+
+        links = []
         if next_token:
-            print("calculating next link")
-            next_link = PagingLinks(next=next_token, request=request).link_next()
-            links.append(next_link)
+            links = await PagingLinks(request=request, next=next_token).get_links()
 
         return Collections(collections=collections, links=links)
 

--- a/stac_fastapi/core/stac_fastapi/core/models/links.py
+++ b/stac_fastapi/core/stac_fastapi/core/models/links.py
@@ -69,7 +69,6 @@ class BaseLinks:
         for name in dir(self):
             if name.startswith("link_") and callable(getattr(self, name)):
                 link = getattr(self, name)()
-                print(f"getting link for {name}")
                 if link is not None:
                     links.append(link)
         return links

--- a/stac_fastapi/core/stac_fastapi/core/models/links.py
+++ b/stac_fastapi/core/stac_fastapi/core/models/links.py
@@ -55,7 +55,7 @@ class BaseLinks:
 
     def link_self(self) -> Dict:
         """Return the self link."""
-        return dict(rel=Relations.self.value, type=MimeTypes.json.value, href=self.url)
+        return dict(rel=Relations.self.value, type=MimeTypes.json.value, href=self.base_url)
 
     def link_root(self) -> Dict:
         """Return the catalog root."""
@@ -118,7 +118,7 @@ class PagingLinks(BaseLinks):
         if self.next is not None:
             method = self.request.method
             if method == "GET":
-                href = merge_params(self.url, {"token": self.next})
+                href = merge_params(self.base_url, {"token": self.next})
                 link = dict(
                     rel=Relations.next.value,
                     type=MimeTypes.json.value,

--- a/stac_fastapi/core/stac_fastapi/core/models/links.py
+++ b/stac_fastapi/core/stac_fastapi/core/models/links.py
@@ -69,6 +69,7 @@ class BaseLinks:
         for name in dir(self):
             if name.startswith("link_") and callable(getattr(self, name)):
                 link = getattr(self, name)()
+                print(f"getting link for {name}")
                 if link is not None:
                     links.append(link)
         return links


### PR DESCRIPTION
Updated handling of links for search results to include correct base url. 
In particular, this resolves the issue seen for the `/search `and `/collection-search`, check the endpoints [here](https://dev.eodatahub.org.uk/stac-fastapi/search?limit=10) and  [here](https://dev.eodatahub.org.uk/stac-fastapi/collection-search?limit=10).