### PR TITLE
Feature/eodhp 27 resource catalogue discovery level search api

### DIFF
--- a/stac_fastapi/core/stac_fastapi/core/base_database_logic.py
+++ b/stac_fastapi/core/stac_fastapi/core/base_database_logic.py
@@ -32,7 +32,9 @@ class BaseDatabaseLogic(abc.ABC):
         pass
 
     @abc.abstractmethod
-    async def create_item(self, catalog_id: str, item: Dict, refresh: bool = False) -> None:
+    async def create_item(
+        self, catalog_id: str, item: Dict, refresh: bool = False
+    ) -> None:
         """Create an item in the database."""
         pass
 
@@ -47,7 +49,6 @@ class BaseDatabaseLogic(abc.ABC):
     async def create_collection(self, collection: Dict, refresh: bool = False) -> None:
         """Create a collection in the database."""
         pass
-
 
     @abc.abstractmethod
     async def find_collection(self, catalog_id: str, collection_id: str) -> Dict:
@@ -72,8 +73,6 @@ class BaseDatabaseLogic(abc.ABC):
         pass
 
     @abc.abstractmethod
-    async def delete_catalog(
-        self, catalog_id: str, refresh: bool = False
-    ) -> None:
+    async def delete_catalog(self, catalog_id: str, refresh: bool = False) -> None:
         """Delete a catalog from the database."""
         pass

--- a/stac_fastapi/core/stac_fastapi/core/base_database_logic.py
+++ b/stac_fastapi/core/stac_fastapi/core/base_database_logic.py
@@ -46,7 +46,9 @@ class BaseDatabaseLogic(abc.ABC):
         pass
 
     @abc.abstractmethod
-    async def create_collection(self, collection: Dict, refresh: bool = False) -> None:
+    async def create_collection(
+        self, catalog_id: str, collection: Dict, refresh: bool = False
+    ) -> None:
         """Create a collection in the database."""
         pass
 
@@ -57,7 +59,7 @@ class BaseDatabaseLogic(abc.ABC):
 
     @abc.abstractmethod
     async def delete_collection(
-        self, collection_id: str, refresh: bool = False
+        self, catalog_id: str, collection_id: str, refresh: bool = False
     ) -> None:
         """Delete a collection from the database."""
         pass

--- a/stac_fastapi/core/stac_fastapi/core/base_database_logic.py
+++ b/stac_fastapi/core/stac_fastapi/core/base_database_logic.py
@@ -32,13 +32,13 @@ class BaseDatabaseLogic(abc.ABC):
         pass
 
     @abc.abstractmethod
-    async def create_item(self, item: Dict, refresh: bool = False) -> None:
+    async def create_item(self, catalog_id: str, item: Dict, refresh: bool = False) -> None:
         """Create an item in the database."""
         pass
 
     @abc.abstractmethod
     async def delete_item(
-        self, item_id: str, collection_id: str, refresh: bool = False
+        self, item_id: str, collection_id: str, catalog_id: str, refresh: bool = False
     ) -> None:
         """Delete an item from the database."""
         pass
@@ -48,13 +48,9 @@ class BaseDatabaseLogic(abc.ABC):
         """Create a collection in the database."""
         pass
 
-    @abc.abstractmethod
-    async def create_catalog(self, catalog: Dict, refresh: bool = False) -> None:
-        """Create a catalog in the database."""
-        pass
 
     @abc.abstractmethod
-    async def find_collection(self, collection_id: str) -> Dict:
+    async def find_collection(self, catalog_id: str, collection_id: str) -> Dict:
         """Find a collection in the database."""
         pass
 
@@ -63,4 +59,21 @@ class BaseDatabaseLogic(abc.ABC):
         self, collection_id: str, refresh: bool = False
     ) -> None:
         """Delete a collection from the database."""
+        pass
+
+    @abc.abstractmethod
+    async def create_catalog(self, catalog: Dict, refresh: bool = False) -> None:
+        """Create a catalog in the database."""
+        pass
+
+    @abc.abstractmethod
+    async def find_catalog(self, catalog_id: str) -> Dict:
+        """Find a catalog in the database."""
+        pass
+
+    @abc.abstractmethod
+    async def delete_catalog(
+        self, catalog_id: str, refresh: bool = False
+    ) -> None:
+        """Delete a catalog from the database."""
         pass

--- a/stac_fastapi/core/stac_fastapi/core/base_database_logic.py
+++ b/stac_fastapi/core/stac_fastapi/core/base_database_logic.py
@@ -20,6 +20,13 @@ class BaseDatabaseLogic(abc.ABC):
         pass
 
     @abc.abstractmethod
+    async def get_all_catalogs(
+        self, token: Optional[str], limit: int
+    ) -> Iterable[Dict[str, Any]]:
+        """Retrieve a list of all catalogs from the database."""
+        pass
+
+    @abc.abstractmethod
     async def get_one_item(self, collection_id: str, item_id: str) -> Dict:
         """Retrieve a single item from the database."""
         pass
@@ -39,6 +46,11 @@ class BaseDatabaseLogic(abc.ABC):
     @abc.abstractmethod
     async def create_collection(self, collection: Dict, refresh: bool = False) -> None:
         """Create a collection in the database."""
+        pass
+
+    @abc.abstractmethod
+    async def create_catalog(self, catalog: Dict, refresh: bool = False) -> None:
+        """Create a catalog in the database."""
         pass
 
     @abc.abstractmethod

--- a/stac_fastapi/core/stac_fastapi/core/core.py
+++ b/stac_fastapi/core/stac_fastapi/core/core.py
@@ -306,7 +306,7 @@ class CoreClient(AsyncBaseCoreClient):
             catalog_id=catalog_id, collection_id=collection_id
         )
         return self.collection_serializer.db_to_stac(
-            collection=collection, base_url=base_url
+            catalog_id=catalog_id, collection=collection, base_url=base_url
         )
 
     async def get_catalog(self, catalog_id: str, **kwargs) -> Collection:
@@ -364,7 +364,9 @@ class CoreClient(AsyncBaseCoreClient):
         )
 
         collections = [
-            self.collection_serializer.db_to_stac(collection, base_url=base_url)
+            self.collection_serializer.db_to_stac(
+                catalog_id=catalog_id, collection=collection, base_url=base_url
+            )
             for collection in collections
         ]
 
@@ -439,7 +441,10 @@ class CoreClient(AsyncBaseCoreClient):
         )
 
         items = [
-            self.item_serializer.db_to_stac(item, base_url=base_url) for item in items
+            self.item_serializer.db_to_stac(
+                catalog_id=catalog_id, item=item, base_url=base_url
+            )
+            for item in items
         ]
 
         context_obj = None
@@ -484,7 +489,9 @@ class CoreClient(AsyncBaseCoreClient):
             collection_id=collection_id,
             catalog_id=catalog_id,
         )
-        return self.item_serializer.db_to_stac(item, base_url)
+        return self.item_serializer.db_to_stac(
+            catalog_id=catalog_id, item=item, base_url=base_url
+        )
 
     @staticmethod
     def _return_date(interval_str):
@@ -710,7 +717,8 @@ class CoreClient(AsyncBaseCoreClient):
         )
 
         items = [
-            self.item_serializer.db_to_stac(item, base_url=base_url) for item in items
+            self.item_serializer.db_to_stac(item=item, base_url=base_url)
+            for item in items
         ]
 
         if self.extension_is_enabled("FieldsExtension"):
@@ -856,7 +864,9 @@ class TransactionsClient(AsyncBaseTransactionsClient):
             catalog_id=catalog_id, collection_id=collection_id, item=item, **kwargs
         )
 
-        return ItemSerializer.db_to_stac(item, base_url)
+        return ItemSerializer.db_to_stac(
+            catalog_id=catalog_id, item=item, base_url=base_url
+        )
 
     @overrides
     async def delete_item(
@@ -903,7 +913,9 @@ class TransactionsClient(AsyncBaseTransactionsClient):
         await self.database.create_collection(
             catalog_id=catalog_id, collection=collection
         )
-        return CollectionSerializer.db_to_stac(collection, base_url)
+        return CollectionSerializer.db_to_stac(
+            catalog_id=catalog_id, collection=collection, base_url=base_url
+        )
 
     @overrides
     async def update_collection(
@@ -944,7 +956,9 @@ class TransactionsClient(AsyncBaseTransactionsClient):
             catalog_id=catalog_id, collection_id=collection_id, collection=collection
         )
 
-        return CollectionSerializer.db_to_stac(collection, base_url)
+        return CollectionSerializer.db_to_stac(
+            catalog_id=catalog_id, collection=collection, base_url=base_url
+        )
 
     @overrides
     async def delete_collection(
@@ -992,7 +1006,7 @@ class TransactionsClient(AsyncBaseTransactionsClient):
 
         await self.database.create_catalog(catalog=catalog)
 
-        return CatalogSerializer.db_to_stac(catalog, base_url)
+        return CatalogSerializer.db_to_stac(catalog=catalog, base_url=base_url)
 
     @overrides
     async def update_catalog(
@@ -1021,7 +1035,7 @@ class TransactionsClient(AsyncBaseTransactionsClient):
         catalog = self.database.catalog_serializer.stac_to_db(catalog, base_url)
         await self.database.update_catalog(catalog_id=catalog_id, catalog=catalog)
 
-        return CatalogSerializer.db_to_stac(catalog, base_url)
+        return CatalogSerializer.db_to_stac(catalog=catalog, base_url=base_url)
 
     @overrides
     async def delete_catalog(

--- a/stac_fastapi/core/stac_fastapi/core/models/links.py
+++ b/stac_fastapi/core/stac_fastapi/core/models/links.py
@@ -55,7 +55,9 @@ class BaseLinks:
 
     def link_self(self) -> Dict:
         """Return the self link."""
-        return dict(rel=Relations.self.value, type=MimeTypes.json.value, href=self.base_url)
+        return dict(
+            rel=Relations.self.value, type=MimeTypes.json.value, href=self.base_url
+        )
 
     def link_root(self) -> Dict:
         """Return the catalog root."""

--- a/stac_fastapi/core/stac_fastapi/core/serializers.py
+++ b/stac_fastapi/core/stac_fastapi/core/serializers.py
@@ -25,7 +25,7 @@ class Serializer(abc.ABC):
 
     @classmethod
     @abc.abstractmethod
-    def db_to_stac(cls, item: dict, base_url: str) -> Any:
+    def db_to_stac(cls, item: dict, base_url: str, catalog_id: str = None) -> Any:
         """Transform database model to STAC object.
 
         Arguments:
@@ -76,7 +76,9 @@ class ItemSerializer(Serializer):
         return stac_data
 
     @classmethod
-    def db_to_stac(cls, item: dict, base_url: str) -> stac_types.Item:
+    def db_to_stac(
+        cls, item: dict, base_url: str, catalog_id: str = None
+    ) -> stac_types.Item:
         """Transform database-ready STAC item to STAC item.
 
         Args:
@@ -89,7 +91,10 @@ class ItemSerializer(Serializer):
         item_id = item["id"]
         collection_id = item["collection"]
         item_links = ItemLinks(
-            collection_id=collection_id, item_id=item_id, base_url=base_url
+            catalog_id=catalog_id,
+            collection_id=collection_id,
+            item_id=item_id,
+            base_url=base_url,
         ).create_links()
 
         original_links = item.get("links", [])
@@ -134,7 +139,9 @@ class CollectionSerializer(Serializer):
         return collection
 
     @classmethod
-    def db_to_stac(cls, collection: dict, base_url: str) -> stac_types.Collection:
+    def db_to_stac(
+        cls, collection: dict, base_url: str, catalog_id: str = None
+    ) -> stac_types.Collection:
         """Transform database model to STAC collection.
 
         Args:
@@ -165,7 +172,7 @@ class CollectionSerializer(Serializer):
 
         # Create the collection links using CollectionLinks
         collection_links = CollectionLinks(
-            collection_id=collection_id, base_url=base_url
+            catalog_id=catalog_id, collection_id=collection_id, base_url=base_url
         ).create_links()
 
         # Add any additional links from the collection dictionary
@@ -277,7 +284,7 @@ class CatalogCollectionSerializer(Serializer):
 
     @classmethod
     def collection_db_to_stac(
-        cls, collection: dict, base_url: str
+        cls, collection: dict, base_url: str, catalog_id: str = None
     ) -> stac_types.Collection:
         """Transform database model to STAC collection.
 
@@ -309,7 +316,7 @@ class CatalogCollectionSerializer(Serializer):
 
         # Create the collection links using CollectionLinks
         collection_links = CollectionLinks(
-            collection_id=collection_id, base_url=base_url
+            cattalog_id=catalog_id, collection_id=collection_id, base_url=base_url
         ).create_links()
 
         # Add any additional links from the collection dictionary
@@ -322,7 +329,9 @@ class CatalogCollectionSerializer(Serializer):
         return stac_types.Collection(**collection)
 
     @classmethod
-    def db_to_stac(cls, data: dict, base_url: str) -> stac_types.Collection:
+    def db_to_stac(
+        cls, data: dict, base_url: str, catalog_id: str = None
+    ) -> stac_types.Collection:
         """Transform database model to STAC catalog or collection.
 
         Args:
@@ -334,6 +343,6 @@ class CatalogCollectionSerializer(Serializer):
         """
         # Determine datatype to serialise and pass to correct serializer function
         if data["type"] == "Collection":
-            return cls.collection_db_to_stac(data, base_url)
+            return cls.collection_db_to_stac(catalog_id, data, base_url)
         elif data["type"] == "Catalog":
             return cls.catalog_db_to_stac(data, base_url)

--- a/stac_fastapi/core/stac_fastapi/core/types/core.py
+++ b/stac_fastapi/core/stac_fastapi/core/types/core.py
@@ -47,7 +47,12 @@ class AsyncBaseTransactionsClient(abc.ABC):
 
     @abc.abstractmethod
     async def update_item(
-        self, catalog_id: str, collection_id: str, item_id: str, item: stac_types.Item, **kwargs
+        self,
+        catalog_id: str,
+        collection_id: str,
+        item_id: str,
+        item: stac_types.Item,
+        **kwargs,
     ) -> Optional[Union[stac_types.Item, Response]]:
         """Perform a complete update on an existing item.
 
@@ -99,7 +104,11 @@ class AsyncBaseTransactionsClient(abc.ABC):
 
     @abc.abstractmethod
     async def update_collection(
-        self, catalog_id: str, collection_id: str, collection: stac_types.Collection, **kwargs
+        self,
+        catalog_id: str,
+        collection_id: str,
+        collection: stac_types.Collection,
+        **kwargs,
     ) -> Optional[Union[stac_types.Collection, Response]]:
         """Perform a complete update on an existing collection.
 
@@ -293,17 +302,6 @@ class AsyncBaseCoreClient(abc.ABC):
         ...
 
     @abc.abstractmethod
-    async def all_collections(self, **kwargs) -> stac_types.Collections:
-        """Get all available collections.
-
-        Called with `GET /collections`.
-
-        Returns:
-            A list of collections.
-        """
-        ...
-
-    @abc.abstractmethod
     async def all_catalogs(self, **kwargs) -> stac_types.Catalogs:
         """Get all available catalogs.
 
@@ -331,9 +329,7 @@ class AsyncBaseCoreClient(abc.ABC):
         ...
 
     @abc.abstractmethod
-    async def get_catalog(
-        self, catalog_id: str, **kwargs
-    ) -> stac_types.Catalog:
+    async def get_catalog(self, catalog_id: str, **kwargs) -> stac_types.Catalog:
         """Get catalog by id.
 
         Called with `GET /catalogs/{catalog_id}`.

--- a/stac_fastapi/core/stac_fastapi/core/types/core.py
+++ b/stac_fastapi/core/stac_fastapi/core/types/core.py
@@ -354,6 +354,7 @@ class AsyncCollectionSearchClient(abc.ABC):
         bbox: Optional[List[NumType]] = None,
         datetime: Optional[Union[str, datetime]] = None,
         limit: Optional[int] = 10,
+        q: Optional[str] = None,
         **kwargs,
     ) -> stac_types.ItemCollection:
         """Cross catalog search (GET) for collections.
@@ -368,15 +369,13 @@ class AsyncCollectionSearchClient(abc.ABC):
         """
         ...
 
-
 @attr.s
-class CollectionSearchClient(abc.ABC):
+class AsyncDiscoverySearchClient(abc.ABC):
     """Defines a pattern for implementing the STAC Collection Search extension."""
 
-    async def get_collection_search(
+    async def get_discovery_search(
         self,
-        bbox: Optional[List[NumType]] = None,
-        datetime: Optional[Union[str, datetime]] = None,
+        q: Optional[str] = None,
         limit: Optional[int] = 10,
         **kwargs,
     ) -> stac_types.ItemCollection:

--- a/stac_fastapi/core/stac_fastapi/core/types/core.py
+++ b/stac_fastapi/core/stac_fastapi/core/types/core.py
@@ -97,6 +97,22 @@ class AsyncBaseTransactionsClient(abc.ABC):
         ...
 
     @abc.abstractmethod
+    async def create_catalog(
+        self, catalog: stac_types.Catalog, **kwargs
+    ) -> Optional[Union[stac_types.Catalog, Response]]:
+        """Create a new catalog.
+
+        Called with `POST /catalogs`.
+
+        Args:
+            catalog: the catalog
+
+        Returns:
+            The catalog that was created.
+        """
+        ...
+
+    @abc.abstractmethod
     async def update_collection(
         self, collection: stac_types.Collection, **kwargs
     ) -> Optional[Union[stac_types.Collection, Response]]:
@@ -237,6 +253,28 @@ class AsyncBaseCoreClient(abc.ABC):
 
         Returns:
             A list of collections.
+        """
+        ...
+
+    @abc.abstractmethod
+    async def all_collections(self, **kwargs) -> stac_types.Collections:
+        """Get all available collections.
+
+        Called with `GET /collections`.
+
+        Returns:
+            A list of collections.
+        """
+        ...
+        
+    @abc.abstractmethod
+    async def all_catalogs(self, **kwargs) -> stac_types.Catalogs:
+        """Get all available catalogs.
+
+        Called with `GET /catalogs`.
+
+        Returns:
+            A list of catalogs.
         """
         ...
 

--- a/stac_fastapi/core/stac_fastapi/core/types/core.py
+++ b/stac_fastapi/core/stac_fastapi/core/types/core.py
@@ -27,6 +27,7 @@ class AsyncBaseTransactionsClient(abc.ABC):
     @abc.abstractmethod
     async def create_item(
         self,
+        catalog_id: str,
         collection_id: str,
         item: Union[stac_types.Item, stac_types.ItemCollection],
         **kwargs,
@@ -46,7 +47,7 @@ class AsyncBaseTransactionsClient(abc.ABC):
 
     @abc.abstractmethod
     async def update_item(
-        self, collection_id: str, item_id: str, item: stac_types.Item, **kwargs
+        self, catalog_id: str, collection_id: str, item_id: str, item: stac_types.Item, **kwargs
     ) -> Optional[Union[stac_types.Item, Response]]:
         """Perform a complete update on an existing item.
 
@@ -65,7 +66,7 @@ class AsyncBaseTransactionsClient(abc.ABC):
 
     @abc.abstractmethod
     async def delete_item(
-        self, item_id: str, collection_id: str, **kwargs
+        self, item_id: str, collection_id: str, catalog_id: str, **kwargs
     ) -> Optional[Union[stac_types.Item, Response]]:
         """Delete an item from a collection.
 
@@ -82,7 +83,7 @@ class AsyncBaseTransactionsClient(abc.ABC):
 
     @abc.abstractmethod
     async def create_collection(
-        self, collection: stac_types.Collection, **kwargs
+        self, catalog_id: str, collection: stac_types.Collection, **kwargs
     ) -> Optional[Union[stac_types.Collection, Response]]:
         """Create a new collection.
 
@@ -93,6 +94,41 @@ class AsyncBaseTransactionsClient(abc.ABC):
 
         Returns:
             The collection that was created.
+        """
+        ...
+
+    @abc.abstractmethod
+    async def update_collection(
+        self, catalog_id: str, collection_id: str, collection: stac_types.Collection, **kwargs
+    ) -> Optional[Union[stac_types.Collection, Response]]:
+        """Perform a complete update on an existing collection.
+
+        Called with `PUT /collections`. It is expected that this item already
+        exists.  The update should do a diff against the saved collection and
+        perform any necessary updates.  Partial updates are not supported by the
+        transactions extension.
+
+        Args:
+            collection: the collection (must be complete)
+
+        Returns:
+            The updated collection.
+        """
+        ...
+
+    @abc.abstractmethod
+    async def delete_collection(
+        self, catalog_id: str, collection_id: str, **kwargs
+    ) -> Optional[Union[stac_types.Collection, Response]]:
+        """Delete a collection.
+
+        Called with `DELETE /collections/{collection_id}`
+
+        Args:
+            collection_id: id of the collection.
+
+        Returns:
+            The deleted collection.
         """
         ...
 
@@ -113,9 +149,9 @@ class AsyncBaseTransactionsClient(abc.ABC):
         ...
 
     @abc.abstractmethod
-    async def update_collection(
-        self, collection: stac_types.Collection, **kwargs
-    ) -> Optional[Union[stac_types.Collection, Response]]:
+    async def update_catalog(
+        self, catalog_id: str, catalog: stac_types.Catalog, **kwargs
+    ) -> Optional[Union[stac_types.Catalog, Response]]:
         """Perform a complete update on an existing collection.
 
         Called with `PUT /collections`. It is expected that this item already
@@ -132,9 +168,9 @@ class AsyncBaseTransactionsClient(abc.ABC):
         ...
 
     @abc.abstractmethod
-    async def delete_collection(
-        self, collection_id: str, **kwargs
-    ) -> Optional[Union[stac_types.Collection, Response]]:
+    async def delete_catalog(
+        self, catalog_id: str, **kwargs
+    ) -> Optional[Union[stac_types.Catalog, Response]]:
         """Delete a collection.
 
         Called with `DELETE /collections/{collection_id}`
@@ -230,7 +266,7 @@ class AsyncBaseCoreClient(abc.ABC):
 
     @abc.abstractmethod
     async def get_item(
-        self, item_id: str, collection_id: str, **kwargs
+        self, item_id: str, collection_id: str, catalog_id: str, **kwargs
     ) -> stac_types.Item:
         """Get item by id.
 
@@ -266,7 +302,7 @@ class AsyncBaseCoreClient(abc.ABC):
             A list of collections.
         """
         ...
-        
+
     @abc.abstractmethod
     async def all_catalogs(self, **kwargs) -> stac_types.Catalogs:
         """Get all available catalogs.
@@ -280,7 +316,7 @@ class AsyncBaseCoreClient(abc.ABC):
 
     @abc.abstractmethod
     async def get_collection(
-        self, collection_id: str, **kwargs
+        self, catalog_id: str, collection_id: str, **kwargs
     ) -> stac_types.Collection:
         """Get collection by id.
 
@@ -291,6 +327,38 @@ class AsyncBaseCoreClient(abc.ABC):
 
         Returns:
             Collection.
+        """
+        ...
+
+    @abc.abstractmethod
+    async def get_catalog(
+        self, catalog_id: str, **kwargs
+    ) -> stac_types.Catalog:
+        """Get catalog by id.
+
+        Called with `GET /catalogs/{catalog_id}`.
+
+        Args:
+            catalog_id: Id of the catalog.
+
+        Returns:
+            Catalog.
+        """
+        ...
+
+    @abc.abstractmethod
+    async def get_catalog_collections(
+        self, catalog_id: str, **kwargs
+    ) -> stac_types.Collections:
+        """Get collections by catalog id.
+
+        Called with `GET /catalogs/{catalog_id}/collections`.
+
+        Args:
+            catalog_id: Id of the catalog.
+
+        Returns:
+            Collections.
         """
         ...
 
@@ -368,6 +436,7 @@ class AsyncCollectionSearchClient(abc.ABC):
             A list of collections matching search criteria.
         """
         ...
+
 
 @attr.s
 class AsyncDiscoverySearchClient(abc.ABC):

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/app.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/app.py
@@ -9,6 +9,7 @@ from stac_fastapi.core.core import (
     CoreClient,
     EsAsyncBaseFiltersClient,
     EsAsyncCollectionSearchClient,
+    EsAsyncDiscoverySearchClient,
     TransactionsClient,
 )
 from stac_fastapi.core.extensions import QueryExtension
@@ -28,6 +29,7 @@ from stac_fastapi.extensions.core import (
     TokenPaginationExtension,
     TransactionExtension,
     CollectionSearchExtension,
+    DiscoverySearchExtension,
 )
 from stac_fastapi.extensions.third_party import BulkTransactionExtension
 
@@ -44,8 +46,16 @@ database_logic = DatabaseLogic()
 collection_search_extension = CollectionSearchExtension(
     client=EsAsyncCollectionSearchClient(database_logic)
 )
-collection_search_extension.conformance_classes.append(
-    "https://api.stacspec.org/v1.0.0-rc.1/collection-search"
+collection_search_extension.conformance_classes.extend([
+    "https://api.stacspec.org/v1.0.0-rc.1/collection-search",
+    "https://api.stacspec.org/v1.0.0-rc.1/collection-search#free-text",]
+)
+
+discovery_search_extension = DiscoverySearchExtension(
+    client=EsAsyncDiscoverySearchClient(database_logic)
+)
+discovery_search_extension.conformance_classes.append(
+    "temporary-discovery-search-extension"
 )
 
 extensions = [
@@ -67,8 +77,9 @@ extensions = [
     SortExtension(),
     TokenPaginationExtension(),
     ContextExtension(),
-    filter_extension,
     collection_search_extension,
+    filter_extension,
+    discovery_search_extension,
 ]
 
 post_request_model = create_post_request_model(extensions)

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/app.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/app.py
@@ -57,8 +57,7 @@ discovery_search_extension = DiscoverySearchExtension(
     client=EsAsyncDiscoverySearchClient(database_logic)
 )
 discovery_search_extension.conformance_classes.extend(
-    ["/catalogues",
-    "/discovery-search"]
+    ["/catalogues", "/discovery-search"]
 )
 
 extensions = [

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/app.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/app.py
@@ -18,6 +18,7 @@ from stac_fastapi.elasticsearch.database_logic import (
     DatabaseLogic,
     create_collection_index,
     create_index_templates,
+    create_catalog_index,
 )
 from stac_fastapi.extensions.core import (
     ContextExtension,
@@ -92,6 +93,7 @@ app.root_path = os.getenv("STAC_FASTAPI_ROOT_PATH", "")
 async def _startup_event() -> None:
     await create_index_templates()
     await create_collection_index()
+    await create_catalog_index()
 
 
 def run() -> None:

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/app.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/app.py
@@ -46,16 +46,19 @@ database_logic = DatabaseLogic()
 collection_search_extension = CollectionSearchExtension(
     client=EsAsyncCollectionSearchClient(database_logic)
 )
-collection_search_extension.conformance_classes.extend([
-    "https://api.stacspec.org/v1.0.0-rc.1/collection-search",
-    "https://api.stacspec.org/v1.0.0-rc.1/collection-search#free-text",]
+collection_search_extension.conformance_classes.extend(
+    [
+        "https://api.stacspec.org/v1.0.0-rc.1/collection-search",
+        "https://api.stacspec.org/v1.0.0-rc.1/collection-search#free-text",
+    ]
 )
 
 discovery_search_extension = DiscoverySearchExtension(
     client=EsAsyncDiscoverySearchClient(database_logic)
 )
-discovery_search_extension.conformance_classes.append(
-    "temporary-discovery-search-extension"
+discovery_search_extension.conformance_classes.extend(
+    ["/catalogues",
+    "/discovery-search"]
 )
 
 extensions = [

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
@@ -55,6 +55,10 @@ DEFAULT_COLLECTIONS_SORT = {
     "id": {"order": "desc"},
 }
 
+DEFAULT_CATALOGS_SORT = {
+    "id": {"order": "desc"},
+}
+
 ES_ITEMS_SETTINGS = {
     "index": {
         "sort.field": list(DEFAULT_SORT.keys()),
@@ -543,6 +547,11 @@ class DatabaseLogic:
     def make_collection_search():
         """Database logic to create a Search instance."""
         return Search().sort(*DEFAULT_COLLECTIONS_SORT)
+    
+    @staticmethod
+    def make_discovery_search():
+        """Database logic to create a Search instance."""
+        return Search().sort(*DEFAULT_CATALOGS_SORT)
 
     @staticmethod
     def apply_ids_filter(search: Search, item_ids: List[str]):
@@ -742,6 +751,85 @@ class DatabaseLogic:
         )
 
         return search.query(Q("bool", filter=[Q("bool", must=must)]))
+    
+    @staticmethod
+    def apply_keyword_collections_filter(search: Search, q: str):
+        keyword_list = [keyword.strip() for keyword in q.split(",")]
+        should = []
+        should.extend(
+            [
+                Q(
+                    "bool",
+                    filter=[
+                        Q(
+                            "match",
+                            title={
+                                "query": q
+                            },
+                        ),
+                    ],
+                ),
+                Q(
+                    "bool",
+                    filter=[
+                        Q(
+                            "match",
+                            description={
+                                "query": q
+                            },
+                        ),
+                    ],
+                ),
+                Q(
+                    "bool",
+                    filter=[
+                        Q(
+                            "terms",
+                            keywords=keyword_list
+                        ),
+                    ],
+                ),
+            ]
+        )
+
+        search = search.query(Q("bool", filter=[Q("bool", should=should)]))
+
+        return search
+
+    @staticmethod
+    def apply_keyword_discovery_filter(search: Search, q: str):
+        should = []
+        should.extend(
+            [
+                Q(
+                    "bool",
+                    filter=[
+                        Q(
+                            "match",
+                            title={
+                                "query": q
+                            },
+                        ),
+                    ],
+                ),
+                Q(
+                    "bool",
+                    filter=[
+                        Q(
+                            "match",
+                            description={
+                                "query": q
+                            },
+                        ),
+                    ],
+                ),
+            ]
+        )
+
+        search = search.query(Q("bool", filter=[Q("bool", should=should)]))
+
+        return search
+
 
     @staticmethod
     def apply_intersects_filter(
@@ -1321,3 +1409,94 @@ class DatabaseLogic:
             body={"query": {"match_all": {}}},
             wait_for_completion=True,
         )
+
+
+    async def execute_discovery_search(
+        self,
+        search: Search,
+        limit: int,
+        base_url: str,
+        token: Optional[str],
+        sort: Optional[Dict[str, Dict[str, str]]],
+        catalog_ids: Optional[List[str]],
+        ignore_unavailable: bool = True,
+    ) -> Tuple[Iterable[Dict[str, Any]], Optional[int], Optional[str]]:
+        """Execute a search query with limit and other optional parameters.
+
+        Args:
+            search (Search): The search query to be executed.
+            limit (int): The maximum number of results to be returned.
+            token (Optional[str]): The token used to return the next set of results.
+            sort (Optional[Dict[str, Dict[str, str]]]): Specifies how the results should be sorted.
+            collection_ids (Optional[List[str]]): The collection ids to search.
+            ignore_unavailable (bool, optional): Whether to ignore unavailable collections. Defaults to True.
+
+        Returns:
+            Tuple[Iterable[Dict[str, Any]], Optional[int], Optional[str]]: A tuple containing:
+                - An iterable of search results, where each result is a dictionary with keys and values representing the
+                fields and values of each document.
+                - The total number of results (if the count could be computed), or None if the count could not be
+                computed.
+                - The token to be used to retrieve the next set of results, or None if there are no more results.
+
+        Raises:
+            NotFoundError: If the collections specified in `collection_ids` do not exist.
+        """
+        search_after = None
+        if token:
+            search_after = urlsafe_b64decode(token.encode()).decode().split(",")
+
+        query = search.query.to_dict() if search.query else None
+
+        index_param = "document"  # indices(collection_ids)
+
+        # First search matching collections
+
+        search_task = asyncio.create_task(
+            self.client.search(
+                index=CATALOGS_INDEX,
+                ignore_unavailable=ignore_unavailable,
+                query=query,
+                sort=sort or DEFAULT_CATALOGS_SORT,
+                search_after=search_after,
+                size=limit,
+            )
+        )
+
+        count_task = asyncio.create_task(
+            self.client.count(
+                index=index_param,
+                ignore_unavailable=ignore_unavailable,
+                body=search.to_dict(count=True),
+            )
+        )
+
+        try:
+            es_response = await search_task
+        except exceptions.NotFoundError:
+            raise NotFoundError(f"Catalogs '{catalog_ids}' do not exist")
+
+        hits = es_response["hits"]["hits"]
+        catalogs = [
+            self.catalog_serializer.db_to_stac(
+                catalog=hit["_source"], base_url=base_url
+            )
+            for hit in hits
+        ]
+
+        next_token = None
+        if hits and (sort_array := hits[-1].get("sort")):
+            next_token = urlsafe_b64encode(
+                ",".join([str(x) for x in sort_array]).encode()
+            ).decode()
+
+        # (1) count should not block returning results, so don't wait for it to be done
+        # (2) don't cancel the task so that it will populate the ES cache for subsequent counts
+        maybe_count = None
+        if count_task.done():
+            try:
+                maybe_count = count_task.result().get("count")
+            except Exception as e:
+                logger.error(f"Count task failed: {e}")
+
+        return catalogs, maybe_count, next_token

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
@@ -11,7 +11,12 @@ from elasticsearch_dsl import Q, Search
 
 from elasticsearch import exceptions, helpers  # type: ignore
 from stac_fastapi.core.extensions import filter
-from stac_fastapi.core.serializers import CollectionSerializer, ItemSerializer, CatalogSerializer
+from stac_fastapi.core.serializers import (
+    CollectionSerializer,
+    ItemSerializer,
+    CatalogSerializer,
+    CatalogCollectionSerializer,
+)
 from stac_fastapi.core.utilities import bbox2polygon
 from stac_fastapi.elasticsearch.config import AsyncElasticsearchSettings
 from stac_fastapi.elasticsearch.config import (
@@ -26,6 +31,7 @@ NumType = Union[float, int]
 
 CATALOGS_INDEX = os.getenv("STAC_CATALOGS_INDEX", "catalogs")
 COLLECTIONS_INDEX = os.getenv("STAC_COLLECTIONS_INDEX", "collections")
+COLLECTIONS_INDEX_PREFIX = os.getenv("STAC_COLLECTIONS_INDEX_PREFIX", "collections_")
 ITEMS_INDEX_PREFIX = os.getenv("STAC_ITEMS_INDEX_PREFIX", "items_")
 ES_INDEX_NAME_UNSUPPORTED_CHARS = {
     "\\",
@@ -43,6 +49,7 @@ ES_INDEX_NAME_UNSUPPORTED_CHARS = {
 }
 
 ITEM_INDICES = f"{ITEMS_INDEX_PREFIX}*,-*kibana*,-{COLLECTIONS_INDEX}*"
+COLLECTION_INDICES = f"{COLLECTIONS_INDEX_PREFIX}*,-*kibana*,-{CATALOGS_INDEX}*"
 
 DEFAULT_SORT = {
     "properties.datetime": {"order": "desc"},
@@ -55,7 +62,7 @@ DEFAULT_COLLECTIONS_SORT = {
     "id": {"order": "desc"},
 }
 
-DEFAULT_CATALOGS_SORT = {
+DEFAULT_DISCOVERY_SORT = {
     "id": {"order": "desc"},
 }
 
@@ -149,6 +156,7 @@ ES_COLLECTIONS_MAPPINGS = {
         "providers": {"type": "object", "enabled": False},
         "links": {"type": "object", "enabled": False},
         "item_assets": {"type": "object", "enabled": False},
+        "keywords": {"type": "keyword"},
     },
     # Collection Search Extension https://github.com/stac-api-extensions/collection-search
     "runtime": {
@@ -224,27 +232,47 @@ ES_COLLECTIONS_MAPPINGS = {
 
 ES_CATALOGS_MAPPINGS = {
     "numeric_detection": False,
-    #"dynamic_templates": ES_MAPPINGS_DYNAMIC_TEMPLATES,
+    # "dynamic_templates": ES_MAPPINGS_DYNAMIC_TEMPLATES,
     "properties": {
         "id": {"type": "keyword"},
         "links": {"type": "object", "enabled": False},
     },
 }
 
-def index_by_collection_id(collection_id: str) -> str:
+
+def index_by_collection_id(collection_id: str = None, catalog_id: Optional[str] = None) -> str:
     """
     Translate a collection id into an Elasticsearch index name.
 
     Args:
         collection_id (str): The collection id to translate into an index name.
+        catalog_id (str): The catalog id to translate into an index name.
 
     Returns:
-        str: The index name derived from the collection id.
+        str: The index name derived from the collection id and catalog id.
     """
-    return f"{ITEMS_INDEX_PREFIX}{''.join(c for c in collection_id.lower() if c not in ES_INDEX_NAME_UNSUPPORTED_CHARS)}"
+    if not collection_id:
+        collection_id = ""
+    collection_and_catalog_id = collection_id
+    if catalog_id:
+        collection_and_catalog_id = collection_and_catalog_id + "_" + catalog_id
+    return f"{ITEMS_INDEX_PREFIX}{''.join(c for c in collection_and_catalog_id.lower() if c not in ES_INDEX_NAME_UNSUPPORTED_CHARS)}"
 
 
-def indices(collection_ids: Optional[List[str]]) -> str:
+def index_by_catalog_id(catalog_id: str) -> str:
+    """
+    Translate a catalog id into an Elasticsearch index name.
+
+    Args:
+        catalog_id (str): The catalog id to translate into an index name.
+
+    Returns:
+        str: The index name derived from the catalog id.
+    """
+    return f"{COLLECTIONS_INDEX_PREFIX}{''.join(c for c in catalog_id.lower() if c not in ES_INDEX_NAME_UNSUPPORTED_CHARS)}"
+
+
+def indices(collection_ids: Optional[List[str]] = None, catalog_ids: Optional[List[str]] = None) -> str:
     """
     Get a comma-separated string of index names for a given list of collection ids.
 
@@ -254,10 +282,27 @@ def indices(collection_ids: Optional[List[str]]) -> str:
     Returns:
         A string of comma-separated index names. If `collection_ids` is None, returns the default indices.
     """
-    if collection_ids is None:
+    if not collection_ids and not catalog_ids:
         return ITEM_INDICES
     else:
-        return ",".join([index_by_collection_id(c) for c in collection_ids])
+        if not collection_ids:
+            collection_ids = [None]
+        return ",".join([index_by_collection_id(collection_id=coll, catalog_id=cat) for coll in collection_ids for cat in catalog_ids])
+
+def collection_indices(catalog_ids: Optional[List[str]]) -> str:
+    """
+    Get a comma-separated string of index names for a given list of catalog ids.
+
+    Args:
+        catalog_ids: A list of catalog ids.
+
+    Returns:
+        A string of comma-separated index names. If `catalog_ids` is None, returns the default collection indices.
+    """
+    if catalog_ids is None:
+        return COLLECTION_INDICES
+    else:
+        return ",".join([index_by_catalog_id(c) for c in catalog_ids])
 
 
 async def create_index_templates() -> None:
@@ -272,7 +317,7 @@ async def create_index_templates() -> None:
     await client.indices.put_template(
         name=f"template_{COLLECTIONS_INDEX}",
         body={
-            "index_patterns": [f"{COLLECTIONS_INDEX}*"],
+            "index_patterns": [f"{COLLECTIONS_INDEX_PREFIX}*"],
             "mappings": ES_COLLECTIONS_MAPPINGS,
         },
     )
@@ -308,8 +353,9 @@ async def create_collection_index() -> None:
         index=f"{COLLECTIONS_INDEX}-000001",
         aliases={COLLECTIONS_INDEX: {}},
     )
-    
+
     await client.close()
+
 
 async def create_catalog_index() -> None:
     """
@@ -328,7 +374,7 @@ async def create_catalog_index() -> None:
     await client.close()
 
 
-async def create_item_index(collection_id: str):
+async def create_item_index(collection_id: str, catalog_id: str):
     """
     Create the index for Items. The settings of the index template will be used implicitly.
 
@@ -340,16 +386,16 @@ async def create_item_index(collection_id: str):
 
     """
     client = AsyncElasticsearchSettings().create_client
-    index_name = index_by_collection_id(collection_id)
+    index_name = index_by_collection_id(collection_id=collection_id, catalog_id=catalog_id)
 
     await client.options(ignore_status=400).indices.create(
-        index=f"{index_by_collection_id(collection_id)}-000001",
+        index=f"{index_name}-000001",
         aliases={index_name: {}},
     )
     await client.close()
 
 
-async def delete_item_index(collection_id: str):
+async def delete_item_index(collection_id: str, catalog_id: str):
     """Delete the index for items in a collection.
 
     Args:
@@ -357,7 +403,7 @@ async def delete_item_index(collection_id: str):
     """
     client = AsyncElasticsearchSettings().create_client
 
-    name = index_by_collection_id(collection_id)
+    name = index_by_collection_id(collection_id=collection_id, catalog_id=catalog_id)
     resolved = await client.indices.resolve_index(name=name)
     if "aliases" in resolved and resolved["aliases"]:
         [alias] = resolved["aliases"]
@@ -367,21 +413,55 @@ async def delete_item_index(collection_id: str):
         await client.indices.delete(index=name)
     await client.close()
 
+async def delete_collection_index(catalog_id: str):
+    """Delete the index for collections in a catalog.
 
-def mk_item_id(item_id: str, collection_id: str):
+    Args:
+        catalog_id (str): The ID of the catalog whose collections index will be deleted.
+    """
+    client = AsyncElasticsearchSettings().create_client
+
+    name = index_by_catalog_id(catalog_id)
+    resolved = await client.indices.resolve_index(name=name)
+    try:
+        if "aliases" in resolved and resolved["aliases"]:
+            [alias] = resolved["aliases"]
+            await client.indices.delete_alias(index=alias["indices"], name=alias["name"])
+            await client.indices.delete(index=alias["indices"])
+        else:
+            await client.indices.delete(index=name)
+        await client.close()
+    except exceptions.NotFoundError:
+        raise NotFoundError(f"Catalog {catalog_id} does not have any associated collections.")
+
+
+def mk_item_id(item_id: str, collection_id: str, catalog_id: str):
     """Create the document id for an Item in Elasticsearch.
 
     Args:
         item_id (str): The id of the Item.
         collection_id (str): The id of the Collection that the Item belongs to.
+        catalog_id (str): The id of the Catalog that the Collection belongs to.
 
     Returns:
-        str: The document id for the Item, combining the Item id and the Collection id, separated by a `|` character.
+        str: The document id for the Item, combining the Item id, the Collection id and the Catalog id, separated by `|` characters.
     """
-    return f"{item_id}|{collection_id}"
+    return f"{item_id}|{collection_id}|{catalog_id}"
+
+def mk_collection_id(collection_id: str, catalog_id: str):
+    """Create the document id for a collection in Elasticsearch.
+
+    Args:
+        collection_id (str): The id of the Collection.
+        catalog_id (str): The id of the Catalog that the Collection belongs to.
+
+    Returns:
+        str: The document id for the Collection, combining the Collection id and the Catalog id, separated by a `|` character.
+    """
+    return f"{collection_id}|{catalog_id}"
 
 
-def mk_actions(collection_id: str, processed_items: List[Item]):
+def mk_actions(catalog_id: str, collection_id: str, processed_items: List[Item]):
     """Create Elasticsearch bulk actions for a list of processed items.
 
     Args:
@@ -397,12 +477,23 @@ def mk_actions(collection_id: str, processed_items: List[Item]):
     """
     return [
         {
-            "_index": index_by_collection_id(collection_id),
-            "_id": mk_item_id(item["id"], item["collection"]),
+            "_index": index_by_collection_id(collection_id=collection_id, catalog_id=catalog_id),
+            "_id": mk_item_id(item_id=item["id"], collection_id=item["collection"], catalog_id=catalog_id),
             "_source": item,
         }
         for item in processed_items
     ]
+
+def get_catalog_id_from_root(collection: Collection):
+        collection_links = collection["links"]
+        for link in collection_links:
+            if link["rel"] == "root":
+                root_href = link["href"]
+                root_href_split = root_href.split("/")
+                catalog_index = root_href_split.index("catalog.json")
+                catalog_id = root_href_split[catalog_index-1]
+                return catalog_id
+        return "uncatalogued-entries"
 
 
 # stac_pydantic classes extend _GeometryBase, which doesn't have a type field,
@@ -424,8 +515,9 @@ class DatabaseLogic:
     collection_serializer: Type[CollectionSerializer] = attr.ib(
         default=CollectionSerializer
     )
-    catalog_serializer: Type[CatalogSerializer] = attr.ib(
-        default=CatalogSerializer
+    catalog_serializer: Type[CatalogSerializer] = attr.ib(default=CatalogSerializer)
+    catalog_collection_serializer: Type[CatalogCollectionSerializer] = attr.ib(
+        default=CatalogCollectionSerializer
     )
 
     """CORE LOGIC"""
@@ -447,7 +539,7 @@ class DatabaseLogic:
             search_after = [token]
 
         response = await self.client.search(
-            index=COLLECTIONS_INDEX,
+            index=f"{COLLECTIONS_INDEX_PREFIX}*",
             body={
                 "sort": [{"id": {"order": "asc"}}],
                 "size": limit,
@@ -469,6 +561,56 @@ class DatabaseLogic:
 
         return collections, next_token
     
+    async def get_catalog_collections(
+        self, catalog_ids: List[str], token: Optional[str], limit: int, base_url: str
+    ) -> Tuple[List[Dict[str, Any]], Optional[str]]:
+        """Retrieve a list of all collections in a catalog from Elasticsearch, supporting pagination.
+
+        Args:
+            catalog_ids (Optional[List[str]]): The catalog ids to search.
+            token (Optional[str]): The pagination token.
+            limit (int): The number of results to return.
+
+        Returns:
+            A tuple of (collections, next pagination token if any).
+        """
+        search_after = None
+        if token:
+            search_after = [token]
+
+        for catalog_id in catalog_ids:
+            await self.check_catalog_exists(catalog_id=catalog_id)
+
+        index_param = collection_indices(catalog_ids=catalog_ids)
+
+        try:
+            response = await self.client.search(
+                index=index_param,
+                body={
+                    "sort": [{"id": {"order": "asc"}}],
+                    "size": limit,
+                    "search_after": search_after,
+                },
+            )
+        except exceptions.NotFoundError:
+            response = None
+            collections = []
+            hits = None
+
+        if response:
+            hits = response["hits"]["hits"]
+            collections = [
+                self.collection_serializer.db_to_stac(
+                    collection=hit["_source"], base_url=base_url
+                )
+                for hit in hits
+            ]
+
+        next_token = None
+        if hits and len(hits) == limit:
+            next_token = hits[-1]["sort"][0]
+
+        return collections, next_token
 
     async def get_all_catalogs(
         self, token: Optional[str], limit: int, base_url: str
@@ -503,14 +645,13 @@ class DatabaseLogic:
             for hit in hits
         ]
 
-
         next_token = None
         if len(hits) == limit:
             next_token = hits[-1]["sort"][0]
 
         return catalogs, next_token
 
-    async def get_one_item(self, collection_id: str, item_id: str) -> Dict:
+    async def get_one_item(self, catalog_id: str, collection_id: str, item_id: str) -> Dict:
         """Retrieve a single item from the database.
 
         Args:
@@ -529,8 +670,8 @@ class DatabaseLogic:
         """
         try:
             item = await self.client.get(
-                index=index_by_collection_id(collection_id),
-                id=mk_item_id(item_id, collection_id),
+                index=index_by_collection_id(collection_id=collection_id, catalog_id=catalog_id),
+                id=mk_item_id(item_id=item_id, collection_id=collection_id, catalog_id=catalog_id),
             )
         except exceptions.NotFoundError:
             raise NotFoundError(
@@ -547,11 +688,11 @@ class DatabaseLogic:
     def make_collection_search():
         """Database logic to create a Search instance."""
         return Search().sort(*DEFAULT_COLLECTIONS_SORT)
-    
+
     @staticmethod
     def make_discovery_search():
         """Database logic to create a Search instance."""
-        return Search().sort(*DEFAULT_CATALOGS_SORT)
+        return Search().sort(*DEFAULT_DISCOVERY_SORT)
 
     @staticmethod
     def apply_ids_filter(search: Search, item_ids: List[str]):
@@ -562,6 +703,11 @@ class DatabaseLogic:
     def apply_collections_filter(search: Search, collection_ids: List[str]):
         """Database logic to search a list of STAC collection ids."""
         return search.filter("terms", collection=collection_ids)
+
+    @staticmethod
+    def apply_catalogs_filter(search: Search, catalog_ids: List[str]):
+        """Database logic to search a list of STAC Catalog ids."""
+        return search.filter("terms", catalog=catalog_ids)
 
     @staticmethod
     def apply_datetime_filter(search: Search, datetime_search):
@@ -751,7 +897,7 @@ class DatabaseLogic:
         )
 
         return search.query(Q("bool", filter=[Q("bool", must=must)]))
-    
+
     @staticmethod
     def apply_keyword_collections_filter(search: Search, q: str):
         keyword_list = [keyword.strip() for keyword in q.split(",")]
@@ -763,9 +909,7 @@ class DatabaseLogic:
                     filter=[
                         Q(
                             "match",
-                            title={
-                                "query": q
-                            },
+                            title={"query": q},
                         ),
                     ],
                 ),
@@ -774,19 +918,14 @@ class DatabaseLogic:
                     filter=[
                         Q(
                             "match",
-                            description={
-                                "query": q
-                            },
+                            description={"query": q},
                         ),
                     ],
                 ),
                 Q(
                     "bool",
                     filter=[
-                        Q(
-                            "terms",
-                            keywords=keyword_list
-                        ),
+                        Q("terms", keywords=keyword_list),
                     ],
                 ),
             ]
@@ -798,38 +937,53 @@ class DatabaseLogic:
 
     @staticmethod
     def apply_keyword_discovery_filter(search: Search, q: str):
-        should = []
-        should.extend(
+        keyword_list = [keyword.strip() for keyword in q.split(",")]
+        # Construct search query for keywords
+        # For catalogues and collections this searches title and description
+        # For collections this also searches keywords
+        should_filter = []
+        should_filter.extend(
             [
                 Q(
                     "bool",
                     filter=[
-                        Q(
-                            "match",
-                            title={
-                                "query": q
-                            },
-                        ),
+                        Q("match", title=q),
                     ],
                 ),
                 Q(
                     "bool",
                     filter=[
-                        Q(
-                            "match",
-                            description={
-                                "query": q
-                            },
-                        ),
+                        Q("match", description=q),
+                    ],
+                ),
+                Q(
+                    "bool",
+                    filter=[
+                        Q("terms", keywords=keyword_list),
                     ],
                 ),
             ]
         )
+        # The following query is then used to score the returned results
+        # Calculate scoring for keyword field
+        should_query = [{"term": {"keywords": keyword}} for keyword in keyword_list]
+        # Calculate scoring for title and description fields
+        should_query.extend(
+            [
+                {
+                    "multi_match": {
+                        "query": q,
+                        "fields": ["title", "description"],
+                        "type": "most_fields",
+                    }
+                }
+            ]
+        )
 
-        search = search.query(Q("bool", filter=[Q("bool", should=should)]))
-
+        search = search.query(
+            Q("bool", filter=[Q("bool", should=should_filter)], should=should_query)
+        )
         return search
-
 
     @staticmethod
     def apply_intersects_filter(
@@ -904,6 +1058,7 @@ class DatabaseLogic:
     async def execute_search(
         self,
         search: Search,
+        catalog_ids: Optional[List[str]],
         limit: int,
         token: Optional[str],
         sort: Optional[Dict[str, Dict[str, str]]],
@@ -931,13 +1086,23 @@ class DatabaseLogic:
         Raises:
             NotFoundError: If the collections specified in `collection_ids` do not exist.
         """
+
+        # Can only provide a collection if you also provide the containing catalog
+        if collection_ids and not catalog_ids:
+            raise Exception("To search specific collection, you must provide the containing catalog.")
+
         search_after = None
         if token:
             search_after = urlsafe_b64decode(token.encode()).decode().split(",")
 
         query = search.query.to_dict() if search.query else None
 
-        index_param = indices(collection_ids)
+        index_param = f"{ITEMS_INDEX_PREFIX}*"
+
+        if collection_ids and catalog_ids:
+            index_param = indices(collection_ids=collection_ids, catalog_ids=catalog_ids)
+        elif catalog_ids:
+            index_param = indices(catalog_ids=catalog_ids).replace("items_", "items_*")
 
         search_task = asyncio.create_task(
             self.client.search(
@@ -982,6 +1147,7 @@ class DatabaseLogic:
                 logger.error(f"Count task failed: {e}")
 
         return items, maybe_count, next_token
+    
 
     async def execute_collection_search(
         self,
@@ -1024,7 +1190,7 @@ class DatabaseLogic:
 
         search_task = asyncio.create_task(
             self.client.search(
-                index=COLLECTIONS_INDEX,
+                index=f"{COLLECTIONS_INDEX_PREFIX}*",
                 ignore_unavailable=ignore_unavailable,
                 query=query,
                 sort=sort or DEFAULT_COLLECTIONS_SORT,
@@ -1073,13 +1239,20 @@ class DatabaseLogic:
 
     """ TRANSACTION LOGIC """
 
-    async def check_collection_exists(self, collection_id: str):
+    async def check_collection_exists(self, collection_id: str, catalog_id: str):
         """Database logic to check if a collection exists."""
-        if not await self.client.exists(index=COLLECTIONS_INDEX, id=collection_id):
-            raise NotFoundError(f"Collection {collection_id} does not exist")
+        full_collection_id = mk_collection_id(collection_id=collection_id, catalog_id=catalog_id)
+        index = index_by_catalog_id(catalog_id=catalog_id)
+        if not await self.client.exists(index=index, id=full_collection_id):
+            raise NotFoundError(f"Collection {collection_id} in catalog {catalog_id} does not exist")
+        
+    async def check_catalog_exists(self, catalog_id: str):
+        """Database logic to check if a catalog exists."""
+        if not await self.client.exists(index=f"{CATALOGS_INDEX}", id=catalog_id):
+            raise NotFoundError(f"Catalog {catalog_id} does not exist")
 
     async def prep_create_item(
-        self, item: Item, base_url: str, exist_ok: bool = False
+        self, catalog_id: str, item: Item, base_url: str, exist_ok: bool = False
     ) -> Item:
         """
         Preps an item for insertion into the database.
@@ -1096,11 +1269,11 @@ class DatabaseLogic:
             ConflictError: If the item already exists in the database.
 
         """
-        await self.check_collection_exists(collection_id=item["collection"])
+        await self.check_collection_exists(collection_id=item["collection"], catalog_id=catalog_id)
 
         if not exist_ok and await self.client.exists(
-            index=index_by_collection_id(item["collection"]),
-            id=mk_item_id(item["id"], item["collection"]),
+            index=index_by_collection_id(collection_id=item["collection"], catalog_id=catalog_id),
+            id=mk_item_id(item_id=item["id"], collection_id=item["collection"], catalog_id=catalog_id),
         ):
             raise ConflictError(
                 f"Item {item['id']} in collection {item['collection']} already exists"
@@ -1109,7 +1282,7 @@ class DatabaseLogic:
         return self.item_serializer.stac_to_db(item, base_url)
 
     def sync_prep_create_item(
-        self, item: Item, base_url: str, exist_ok: bool = False
+        self, catalog_id: str, item: Item, base_url: str, exist_ok: bool = False
     ) -> Item:
         """
         Prepare an item for insertion into the database.
@@ -1136,8 +1309,8 @@ class DatabaseLogic:
             raise NotFoundError(f"Collection {collection_id} does not exist")
 
         if not exist_ok and self.sync_client.exists(
-            index=index_by_collection_id(collection_id),
-            id=mk_item_id(item_id, collection_id),
+            index=index_by_collection_id(collection_id=collection_id, catalog_id=catalog_id),
+            id=mk_item_id(item_id=item_id, collection_id=collection_id, catalog_id=catalog_id),
         ):
             raise ConflictError(
                 f"Item {item_id} in collection {collection_id} already exists"
@@ -1145,7 +1318,7 @@ class DatabaseLogic:
 
         return self.item_serializer.stac_to_db(item, base_url)
 
-    async def create_item(self, item: Item, refresh: bool = False):
+    async def create_item(self, catalog_id: str, item: Item, refresh: bool = False):
         """Database logic for creating one item.
 
         Args:
@@ -1162,19 +1335,19 @@ class DatabaseLogic:
         item_id = item["id"]
         collection_id = item["collection"]
         es_resp = await self.client.index(
-            index=index_by_collection_id(collection_id),
-            id=mk_item_id(item_id, collection_id),
+            index=index_by_collection_id(collection_id=collection_id, catalog_id=catalog_id),
+            id=mk_item_id(item_id=item_id, collection_id=collection_id, catalog_id=catalog_id),
             document=item,
             refresh=refresh,
         )
 
         if (meta := es_resp.get("meta")) and meta.get("status") == 409:
             raise ConflictError(
-                f"Item {item_id} in collection {collection_id} already exists"
+                f"Item {item_id} in collection {collection_id} in catalog {catalog_id} already exists"
             )
 
     async def delete_item(
-        self, item_id: str, collection_id: str, refresh: bool = False
+        self, item_id: str, collection_id: str, catalog_id: str, refresh: bool = False
     ):
         """Delete a single item from the database.
 
@@ -1188,41 +1361,214 @@ class DatabaseLogic:
         """
         try:
             await self.client.delete(
-                index=index_by_collection_id(collection_id),
-                id=mk_item_id(item_id, collection_id),
+                index=index_by_collection_id(collection_id=collection_id, catalog_id=catalog_id),
+                id=mk_item_id(item_id=item_id, collection_id=collection_id, catalog_id=catalog_id),
                 refresh=refresh,
             )
         except exceptions.NotFoundError:
             raise NotFoundError(
-                f"Item {item_id} in collection {collection_id} not found"
+                f"Item {item_id} in collection {collection_id} in catalog {catalog_id} not found"
             )
-
-    async def create_collection(self, collection: Collection, refresh: bool = False):
-        """Create a single collection in the database.
+        
+        
+    async def prep_create_collection(
+        self, catalog_id: str, collection: Collection, base_url: str, exist_ok: bool = False
+    ) -> Item:
+        """
+        Preps a collection for insertion into the database.
 
         Args:
-            collection (Collection): The Collection object to be created.
-            refresh (bool, optional): Whether to refresh the index after the creation. Default is False.
+            catalog_id (str) : The id of the catalog into which the collection will be inserted.
+            collection (Collection): The collection to be prepped for insertion.
+            base_url (str): The base URL used to create the collection's self URL.
+            exist_ok (bool): Indicates whether the collection can exist already.
+
+        Returns:
+            Collection: The prepped item.
 
         Raises:
-            ConflictError: If a Collection with the same id already exists in the database.
+            ConflictError: If the collection already exists in the catalog in the database.
 
-        Notes:
-            A new index is created for the items in the Collection using the `create_item_index` function.
+        """
+        await self.check_catalog_exists(catalog_id=catalog_id)
+        if not exist_ok and await self.client.exists(
+            index=index_by_catalog_id(catalog_id),
+            id=mk_collection_id(collection["id"], catalog_id),
+        ):
+            raise ConflictError(
+                f"Collection {collection['id']} in catalog {catalog_id} already exists"
+            )
+
+        return self.collection_serializer.stac_to_db(collection, base_url)
+
+    def sync_prep_create_collection(
+        self, catalog_id: str, collection: Collection, base_url: str, exist_ok: bool = False
+    ) -> Item:
+        """
+        Prepare an item for insertion into the database.
+
+        This method performs pre-insertion preparation on the given `item`,
+        such as checking if the collection the item belongs to exists,
+        and optionally verifying that an item with the same ID does not already exist in the database.
+
+        Args:
+            catalog_id (str) : The id of the catalog into which the collection will be inserted.
+            collection (Collection): The collection to be prepped for insertion.
+            base_url (str): The base URL used for constructing URLs for the item.
+            exist_ok (bool): Indicates whether the item can exist already.
+
+        Returns:
+            Item: The item after preparation is done.
+
+        Raises:
+            NotFoundError: If the collection that the item belongs to does not exist in the database.
+            ConflictError: If a collection with the same ID already exists in the catalog.
         """
         collection_id = collection["id"]
+        catalog_id = catalog_id
+        if not self.sync_client.exists(index=CATALOGS_INDEX, id=catalog_id):
+            raise NotFoundError(f"Catalog {catalog_id} does not exist")
 
-        if await self.client.exists(index=COLLECTIONS_INDEX, id=collection_id):
-            raise ConflictError(f"Collection {collection_id} already exists")
+        if not exist_ok and self.sync_client.exists(
+            index=index_by_catalog_id(catalog_id),
+            id=mk_collection_id(collection_id=collection_id, catalog_id=catalog_id),
+        ):
+            raise ConflictError(
+                f"Collection {collection_id} in catalog {catalog_id} already exists"
+            )
 
-        await self.client.index(
-            index=COLLECTIONS_INDEX,
-            id=collection_id,
+        return self.collection_serializer.stac_to_db(collection, base_url)
+
+    async def create_collection(self, catalog_id: str, collection: Collection, refresh: bool = False):
+        """Database logic for creating one item.
+
+        Args:
+            catalog_id (str) : The id of the catalog into which the collection will be inserted.
+            collection (Collection): The collection to be created.
+            refresh (bool, optional): Refresh the index after performing the operation. Defaults to False.
+
+        Raises:
+            ConflictError: If the collection already exists in the catalog in the database.
+
+        Returns:
+            None
+        """
+        # todo: check if collection exists, but cache
+        collection_id = collection["id"]
+        es_resp = await self.client.index(
+            index=index_by_catalog_id(catalog_id),
+            id=mk_collection_id(collection_id, catalog_id),
             document=collection,
             refresh=refresh,
         )
 
-        await create_item_index(collection_id)
+        if (meta := es_resp.get("meta")) and meta.get("status") == 409:
+            raise ConflictError(
+                f"Collection {collection_id} in catalog {catalog_id} already exists"
+            )
+
+
+    async def find_collection(self, catalog_id: str, collection_id: str) -> Collection:
+        """Find and return a collection from the database.
+
+        Args:
+            self: The instance of the object calling this function.
+            catalog_id (str): The ID of the collection to be found.
+            collection_id (str): The ID of the collection to be found.
+
+        Returns:
+            Collection: The found collection, represented as a `Collection` object.
+
+        Raises:
+            NotFoundError: If the collection with the given `collection_id` is not found in the given catalog in the database.
+
+        Notes:
+            This function searches for a collection in the database using the specified `collection_id` and returns the found
+            collection as a `Collection` object. If the collection is not found, a `NotFoundError` is raised.
+        """
+        full_collection_id = mk_collection_id(collection_id, catalog_id)
+        try:
+            collection = await self.client.get(
+                index=index_by_catalog_id(catalog_id), id=full_collection_id
+            )
+        except exceptions.NotFoundError:
+            raise NotFoundError(f"Collection {collection_id} in catalog {catalog_id} not found")
+
+        return collection["_source"]
+    
+
+    async def update_collection(
+        self, catalog_id: str, collection_id: str, collection: Collection, refresh: bool = False
+    ):
+        """Update a collection from the database.
+
+        Args:
+            self: The instance of the object calling this function.
+            catalog_id (str): The ID of the catalog containing the collection to be updated.
+            collection_id (str): The ID of the collection to be updated.
+            collection (Collection): The Collection object to be used for the update.
+
+        Raises:
+            NotFoundError: If the collection with the given `collection_id` is not
+            found in the database.
+
+        Notes:
+            This function updates the collection in the database using the specified
+            `collection_id` and with the collection specified in the `Collection` object.
+            If the collection is not found, a `NotFoundError` is raised.
+        """
+        await self.find_collection(catalog_id=catalog_id, collection_id=collection_id)
+
+        if collection_id != collection["id"]:
+            await self.create_collection(catalog_id, collection, refresh=refresh)
+
+            await self.client.reindex(
+                body={
+                    "dest": {"index": f"{ITEMS_INDEX_PREFIX}{collection['id']}_{catalog_id}"},
+                    "source": {"index": f"{ITEMS_INDEX_PREFIX}{collection_id}_{catalog_id}"},
+                    "script": {
+                        "lang": "painless",
+                        "source": f"""ctx._id = ctx._id.replace('{collection_id}', '{collection["id"]}'); ctx._source.collection = '{collection["id"]}' ;""",
+                    },
+                },
+                wait_for_completion=True,
+                refresh=refresh,
+            )
+
+            await self.delete_collection(catalog_id=catalog_id, collection_id=collection_id)
+
+        else:
+            collections_index = index_by_catalog_id(catalog_id)
+            await self.client.index(
+                index=collections_index,
+                id=mk_collection_id(collection_id, catalog_id),
+                document=collection,
+                refresh=refresh,
+            )
+
+    async def delete_collection(self, catalog_id: str, collection_id: str, refresh: bool = False):
+        """Delete a collection from the database.
+
+        Parameters:
+            self: The instance of the object calling this function.
+            catalog_id (str): The ID of the catalog containing the collection to be deleted.
+            collection_id (str): The ID of the collection to be deleted.
+            refresh (bool): Whether to refresh the index after the deletion (default: False).
+
+        Raises:
+            NotFoundError: If the collection with the given `collection_id` is not found in the database.
+
+        Notes:
+            This function first verifies that the collection with the specified `collection_id` exists in the database, and then
+            deletes the collection. If `refresh` is set to True, the index is refreshed after the deletion. Additionally, this
+            function also calls `delete_item_index` to delete the index for the items in the collection.
+        """
+        await self.find_collection(catalog_id=catalog_id, collection_id=collection_id)
+        await self.client.delete(
+            index=index_by_catalog_id(catalog_id), id=mk_collection_id(collection_id, catalog_id), refresh=refresh
+        )
+        await delete_item_index(collection_id=collection_id, catalog_id=catalog_id)
+
 
     async def create_catalog(self, catalog: Catalog, refresh: bool = False):
         """Create a single catalog in the database.
@@ -1242,14 +1588,16 @@ class DatabaseLogic:
         if await self.client.exists(index=CATALOGS_INDEX, id=catalog_id):
             raise ConflictError(f"Catalog {catalog_id} already exists")
 
-        output = await self.client.index(
+        await self.client.index(
             index=CATALOGS_INDEX,
             id=catalog_id,
             document=catalog,
             refresh=refresh,
         )
 
-    async def find_collection(self, collection_id: str) -> Collection:
+
+
+    async def find_catalog(self, catalog_id: str) -> Catalog:
         """Find and return a collection from the database.
 
         Args:
@@ -1267,16 +1615,17 @@ class DatabaseLogic:
             collection as a `Collection` object. If the collection is not found, a `NotFoundError` is raised.
         """
         try:
-            collection = await self.client.get(
-                index=COLLECTIONS_INDEX, id=collection_id
+            catalog = await self.client.get(
+                index=CATALOGS_INDEX, id=catalog_id
             )
         except exceptions.NotFoundError:
-            raise NotFoundError(f"Collection {collection_id} not found")
+            raise NotFoundError(f"Catalog {catalog_id} not found")
 
-        return collection["_source"]
+        return catalog["_source"]
+    
 
-    async def update_collection(
-        self, collection_id: str, collection: Collection, refresh: bool = False
+    async def update_catalog(
+        self, catalog_id: str, catalog: Catalog, refresh: bool = False
     ):
         """Update a collection from the database.
 
@@ -1294,35 +1643,34 @@ class DatabaseLogic:
             `collection_id` and with the collection specified in the `Collection` object.
             If the collection is not found, a `NotFoundError` is raised.
         """
-        await self.find_collection(collection_id=collection_id)
-
-        if collection_id != collection["id"]:
-            await self.create_collection(collection, refresh=refresh)
+        await self.find_catalog(catalog_id=catalog_id)
+        if catalog_id != catalog["id"]:
+            await self.create_catalog(catalog, refresh=refresh)
 
             await self.client.reindex(
                 body={
-                    "dest": {"index": f"{ITEMS_INDEX_PREFIX}{collection['id']}"},
-                    "source": {"index": f"{ITEMS_INDEX_PREFIX}{collection_id}"},
+                    "dest": {"index": f"{COLLECTIONS_INDEX_PREFIX}{catalog['id']}"},
+                    "source": {"index": index_by_catalog_id(catalog_id)},
                     "script": {
                         "lang": "painless",
-                        "source": f"""ctx._id = ctx._id.replace('{collection_id}', '{collection["id"]}'); ctx._source.collection = '{collection["id"]}' ;""",
+                        "source": f"""ctx._id = ctx._id.replace('{catalog_id}', '{catalog["id"]}'); ctx._source.collection = '{catalog["id"]}' ;""",
                     },
                 },
                 wait_for_completion=True,
                 refresh=refresh,
             )
 
-            await self.delete_collection(collection_id)
+            await self.delete_catalog(catalog_id)
 
         else:
             await self.client.index(
-                index=COLLECTIONS_INDEX,
-                id=collection_id,
-                document=collection,
+                index=CATALOGS_INDEX,
+                id=catalog_id,
+                document=catalog,
                 refresh=refresh,
             )
 
-    async def delete_collection(self, collection_id: str, refresh: bool = False):
+    async def delete_catalog(self, catalog_id: str, refresh: bool = False):
         """Delete a collection from the database.
 
         Parameters:
@@ -1336,16 +1684,20 @@ class DatabaseLogic:
         Notes:
             This function first verifies that the collection with the specified `collection_id` exists in the database, and then
             deletes the collection. If `refresh` is set to True, the index is refreshed after the deletion. Additionally, this
-            function also calls `delete_item_index` to delete the index for the items in the collection.
+            function also calls `delete_collection_index` to delete the index for the collections in the catalog.
         """
-        await self.find_collection(collection_id=collection_id)
+        await self.find_catalog(catalog_id=catalog_id)
         await self.client.delete(
-            index=COLLECTIONS_INDEX, id=collection_id, refresh=refresh
+            index=CATALOGS_INDEX, id=catalog_id, refresh=refresh
         )
-        await delete_item_index(collection_id)
+        try:
+            await delete_collection_index(catalog_id)
+        except exceptions.NotFoundError:
+            raise NotFoundError(f"Catalog {catalog_id} does not exist")
+
 
     async def bulk_async(
-        self, collection_id: str, processed_items: List[Item], refresh: bool = False
+        self, catalog_id: str, collection_id: str, processed_items: List[Item], refresh: bool = False
     ) -> None:
         """Perform a bulk insert of items into the database asynchronously.
 
@@ -1363,13 +1715,13 @@ class DatabaseLogic:
         """
         await helpers.async_bulk(
             self.client,
-            mk_actions(collection_id, processed_items),
+            mk_actions(catalog_id, collection_id, processed_items),
             refresh=refresh,
             raise_on_error=False,
         )
 
     def bulk_sync(
-        self, collection_id: str, processed_items: List[Item], refresh: bool = False
+        self, catalog_id: str, collection_id: str, processed_items: List[Item], refresh: bool = False
     ) -> None:
         """Perform a bulk insert of items into the database synchronously.
 
@@ -1387,7 +1739,7 @@ class DatabaseLogic:
         """
         helpers.bulk(
             self.sync_client,
-            mk_actions(collection_id, processed_items),
+            mk_actions(catalog_id, collection_id, processed_items),
             refresh=refresh,
             raise_on_error=False,
         )
@@ -1409,7 +1761,6 @@ class DatabaseLogic:
             body={"query": {"match_all": {}}},
             wait_for_completion=True,
         )
-
 
     async def execute_discovery_search(
         self,
@@ -1450,14 +1801,12 @@ class DatabaseLogic:
 
         index_param = "document"  # indices(collection_ids)
 
-        # First search matching collections
-
         search_task = asyncio.create_task(
             self.client.search(
-                index=CATALOGS_INDEX,
+                index=[CATALOGS_INDEX, f"{COLLECTIONS_INDEX_PREFIX}*"],
                 ignore_unavailable=ignore_unavailable,
                 query=query,
-                sort=sort or DEFAULT_CATALOGS_SORT,
+                sort=sort or DEFAULT_DISCOVERY_SORT,
                 search_after=search_after,
                 size=limit,
             )
@@ -1477,9 +1826,9 @@ class DatabaseLogic:
             raise NotFoundError(f"Catalogs '{catalog_ids}' do not exist")
 
         hits = es_response["hits"]["hits"]
-        catalogs = [
-            self.catalog_serializer.db_to_stac(
-                catalog=hit["_source"], base_url=base_url
+        data = [
+            self.catalog_collection_serializer.db_to_stac(
+                data=hit["_source"], base_url=base_url
             )
             for hit in hits
         ]
@@ -1499,4 +1848,4 @@ class DatabaseLogic:
             except Exception as e:
                 logger.error(f"Count task failed: {e}")
 
-        return catalogs, maybe_count, next_token
+        return data, maybe_count, next_token


### PR DESCRIPTION
## Implement discovery level search
- Added new endpoint to allow free-text searching of collections and catalogues:
  - New endpoints: 
    - Discovery Search (GET/POST)
  - This queries title, description and keyword fields when available
- Added support for catalogues to split up collections and items into catalogues of data
  - This leads to updates for the following endpoints to filter by catalogues:
    - Get Collection
    - Get ItemCollection
    - Get CatalogCollections
    - Create Item
    - Update Item
    - Delete Item
    - Create Collection
    - Update Collection
    - Delete Collection
  - New endpoints added for catalogues:
    - Update Catalog
    - Create Catalog
    - Delete Catalog
    - Get Catalogs

### Other changes
- Minor update to the datetime handling for Get ItemCollection to include string converter.
- Formatting changes using Black and Ruff