### PR TITLE
Patch/correct update catalog functionality

### DIFF
--- a/stac_fastapi/core/stac_fastapi/core/core.py
+++ b/stac_fastapi/core/stac_fastapi/core/core.py
@@ -1382,7 +1382,6 @@ class EsAsyncDiscoverySearchClient(AsyncDiscoverySearchClient):
                 limit=limit,
                 token=None,
                 sort=sort,
-                catalog_ids=None,  # search_request.collections,
                 base_url=base_url,
             )
         )

--- a/stac_fastapi/core/stac_fastapi/core/core.py
+++ b/stac_fastapi/core/stac_fastapi/core/core.py
@@ -23,17 +23,17 @@ from stac_fastapi.core.base_database_logic import BaseDatabaseLogic
 from stac_fastapi.core.base_settings import ApiBaseSettings
 from stac_fastapi.core.models.links import PagingLinks
 from stac_fastapi.core.serializers import (
+    CatalogCollectionSerializer,
+    CatalogSerializer,
     CollectionSerializer,
     ItemSerializer,
-    CatalogSerializer,
-    CatalogCollectionSerializer,
 )
 from stac_fastapi.core.session import Session
 from stac_fastapi.core.types.core import (
     AsyncBaseCoreClient,
     AsyncBaseFiltersClient,
-    AsyncCollectionSearchClient,
     AsyncBaseTransactionsClient,
+    AsyncCollectionSearchClient,
     AsyncDiscoverySearchClient,
 )
 from stac_fastapi.extensions.third_party.bulk_transactions import (
@@ -47,17 +47,17 @@ from stac_fastapi.types.conformance import BASE_CONFORMANCE_CLASSES
 from stac_fastapi.types.extension import ApiExtension
 from stac_fastapi.types.requests import get_base_url
 from stac_fastapi.types.search import (
-    BaseSearchPostRequest,
     BaseCollectionSearchPostRequest,
     BaseDiscoverySearchPostRequest,
+    BaseSearchPostRequest,
 )
 from stac_fastapi.types.stac import (
+    Catalogs,
+    CatalogsAndCollections,
     Collection,
     Collections,
     Item,
     ItemCollection,
-    Catalogs,
-    CatalogsAndCollections,
 )
 
 logger = logging.getLogger(__name__)

--- a/stac_fastapi/core/stac_fastapi/core/serializers.py
+++ b/stac_fastapi/core/stac_fastapi/core/serializers.py
@@ -9,10 +9,10 @@ import attr
 from stac_fastapi.core.datetime_utils import now_to_rfc3339_str
 from stac_fastapi.types import stac as stac_types
 from stac_fastapi.types.links import (
+    CatalogLinks,
     CollectionLinks,
     ItemLinks,
     resolve_links,
-    CatalogLinks,
 )
 
 

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/app.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/app.py
@@ -17,19 +17,19 @@ from stac_fastapi.core.session import Session
 from stac_fastapi.elasticsearch.config import ElasticsearchSettings
 from stac_fastapi.elasticsearch.database_logic import (
     DatabaseLogic,
+    create_catalog_index,
     create_collection_index,
     create_index_templates,
-    create_catalog_index,
 )
 from stac_fastapi.extensions.core import (
+    CollectionSearchExtension,
     ContextExtension,
+    DiscoverySearchExtension,
     FieldsExtension,
     FilterExtension,
     SortExtension,
     TokenPaginationExtension,
     TransactionExtension,
-    CollectionSearchExtension,
-    DiscoverySearchExtension,
 )
 from stac_fastapi.extensions.third_party import BulkTransactionExtension
 

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
@@ -1728,6 +1728,7 @@ class DatabaseLogic:
         if catalog_id != catalog["id"]:
             await self.create_catalog(catalog, refresh=refresh)
 
+            # Reindex collections within this catalog
             await self.client.reindex(
                 body={
                     "dest": {"index": f"{COLLECTIONS_INDEX_PREFIX}{catalog['id']}"},
@@ -1956,7 +1957,7 @@ class DatabaseLogic:
         try:
             es_response = await search_task
         except exceptions.NotFoundError:
-            raise NotFoundError(f"Catalog or Collection missing during search.")
+            raise NotFoundError("Catalog or Collection missing during search.")
 
         hits = es_response["hits"]["hits"]
         data = [

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
@@ -1221,8 +1221,6 @@ class DatabaseLogic:
 
         query = search.query.to_dict() if search.query else None
 
-        index_param = "document"  # indices(collection_ids)
-
         search_task = asyncio.create_task(
             self.client.search(
                 index=f"{COLLECTIONS_INDEX_PREFIX}*",
@@ -1236,16 +1234,13 @@ class DatabaseLogic:
 
         count_task = asyncio.create_task(
             self.client.count(
-                index=index_param,
+                index=f"{COLLECTIONS_INDEX_PREFIX}*",
                 ignore_unavailable=ignore_unavailable,
                 body=search.to_dict(count=True),
             )
         )
 
-        try:
-            es_response = await search_task
-        except exceptions.NotFoundError:
-            raise NotFoundError(f"Collections '{collection_ids}' do not exist")
+        es_response = await search_task
 
         hits = es_response["hits"]["hits"]
         collections = [
@@ -1933,8 +1928,6 @@ class DatabaseLogic:
 
         query = search.query.to_dict() if search.query else None
 
-        index_param = "document"  # indices(collection_ids)
-
         search_task = asyncio.create_task(
             self.client.search(
                 index=[CATALOGS_INDEX, f"{COLLECTIONS_INDEX_PREFIX}*"],
@@ -1948,16 +1941,13 @@ class DatabaseLogic:
 
         count_task = asyncio.create_task(
             self.client.count(
-                index=index_param,
+                index=[CATALOGS_INDEX, f"{COLLECTIONS_INDEX_PREFIX}*"],
                 ignore_unavailable=ignore_unavailable,
                 body=search.to_dict(count=True),
             )
         )
 
-        try:
-            es_response = await search_task
-        except exceptions.NotFoundError:
-            raise NotFoundError("Catalog or Collection missing during search.")
+        es_response = await search_task
 
         hits = es_response["hits"]["hits"]
         data = [

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
@@ -12,10 +12,10 @@ from elasticsearch_dsl import Q, Search
 from elasticsearch import exceptions, helpers  # type: ignore
 from stac_fastapi.core.extensions import filter
 from stac_fastapi.core.serializers import (
+    CatalogCollectionSerializer,
+    CatalogSerializer,
     CollectionSerializer,
     ItemSerializer,
-    CatalogSerializer,
-    CatalogCollectionSerializer,
 )
 from stac_fastapi.core.utilities import bbox2polygon
 from stac_fastapi.elasticsearch.config import AsyncElasticsearchSettings
@@ -23,7 +23,7 @@ from stac_fastapi.elasticsearch.config import (
     ElasticsearchSettings as SyncElasticsearchSettings,
 )
 from stac_fastapi.types.errors import ConflictError, NotFoundError
-from stac_fastapi.types.stac import Collection, Item, Catalog
+from stac_fastapi.types.stac import Catalog, Collection, Item
 
 logger = logging.getLogger(__name__)
 
@@ -1728,7 +1728,7 @@ class DatabaseLogic:
         if catalog_id != catalog["id"]:
             await self.create_catalog(catalog, refresh=refresh)
 
-            # Reindex collections within this catalog
+            # Reindex collections in this catalog
             await self.client.reindex(
                 body={
                     "dest": {"index": f"{COLLECTIONS_INDEX_PREFIX}{catalog['id']}"},
@@ -1742,7 +1742,7 @@ class DatabaseLogic:
                 refresh=refresh,
             )
 
-            # Reindex items within each collection within this catalog
+            # Reindex items within each collection in this catalog
             try:
                 # Get all collections contained in this catalog
                 index_param = collection_indices(catalog_ids=[catalog_id])


### PR DESCRIPTION
Patch to correct update_catalog functionality to reindex items as well as collections when catalog ID is updated.
Also remove unnecessary parameter from discover-search function as part of general code clean-up.