### PR TITLE
Feature/eodhp 332 allow transaction extensions to be disabled

### DIFF
--- a/stac_fastapi/core/stac_fastapi/core/core.py
+++ b/stac_fastapi/core/stac_fastapi/core/core.py
@@ -23,17 +23,17 @@ from stac_fastapi.core.base_database_logic import BaseDatabaseLogic
 from stac_fastapi.core.base_settings import ApiBaseSettings
 from stac_fastapi.core.models.links import PagingLinks
 from stac_fastapi.core.serializers import (
+    CatalogCollectionSerializer,
+    CatalogSerializer,
     CollectionSerializer,
     ItemSerializer,
-    CatalogSerializer,
-    CatalogCollectionSerializer,
 )
 from stac_fastapi.core.session import Session
 from stac_fastapi.core.types.core import (
     AsyncBaseCoreClient,
     AsyncBaseFiltersClient,
-    AsyncCollectionSearchClient,
     AsyncBaseTransactionsClient,
+    AsyncCollectionSearchClient,
     AsyncDiscoverySearchClient,
 )
 from stac_fastapi.extensions.third_party.bulk_transactions import (
@@ -47,17 +47,17 @@ from stac_fastapi.types.conformance import BASE_CONFORMANCE_CLASSES
 from stac_fastapi.types.extension import ApiExtension
 from stac_fastapi.types.requests import get_base_url
 from stac_fastapi.types.search import (
-    BaseSearchPostRequest,
     BaseCollectionSearchPostRequest,
     BaseDiscoverySearchPostRequest,
+    BaseSearchPostRequest,
 )
 from stac_fastapi.types.stac import (
+    Catalogs,
+    CatalogsAndCollections,
     Collection,
     Collections,
     Item,
     ItemCollection,
-    Catalogs,
-    CatalogsAndCollections,
 )
 
 logger = logging.getLogger(__name__)

--- a/stac_fastapi/core/stac_fastapi/core/serializers.py
+++ b/stac_fastapi/core/stac_fastapi/core/serializers.py
@@ -9,10 +9,10 @@ import attr
 from stac_fastapi.core.datetime_utils import now_to_rfc3339_str
 from stac_fastapi.types import stac as stac_types
 from stac_fastapi.types.links import (
+    CatalogLinks,
     CollectionLinks,
     ItemLinks,
     resolve_links,
-    CatalogLinks,
 )
 
 

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/app.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/app.py
@@ -112,9 +112,10 @@ app.root_path = os.getenv("STAC_FASTAPI_ROOT_PATH", "")
 
 @app.on_event("startup")
 async def _startup_event() -> None:
-    await create_index_templates()
-    await create_collection_index()
-    await create_catalog_index()
+    if os.getenv("STAC_FASTAPI_ENABLE_TRANSACTIONS", "false") == "true":
+        await create_index_templates()
+        await create_collection_index()
+        await create_catalog_index()
 
 
 def run() -> None:

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
@@ -12,10 +12,10 @@ from elasticsearch_dsl import Q, Search
 from elasticsearch import exceptions, helpers  # type: ignore
 from stac_fastapi.core.extensions import filter
 from stac_fastapi.core.serializers import (
+    CatalogCollectionSerializer,
+    CatalogSerializer,
     CollectionSerializer,
     ItemSerializer,
-    CatalogSerializer,
-    CatalogCollectionSerializer,
 )
 from stac_fastapi.core.utilities import bbox2polygon
 from stac_fastapi.elasticsearch.config import AsyncElasticsearchSettings
@@ -23,7 +23,7 @@ from stac_fastapi.elasticsearch.config import (
     ElasticsearchSettings as SyncElasticsearchSettings,
 )
 from stac_fastapi.types.errors import ConflictError, NotFoundError
-from stac_fastapi.types.stac import Collection, Item, Catalog
+from stac_fastapi.types.stac import Catalog, Collection, Item
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Disable transaction extentions using environment variable.
Updated to allow transaction extensions (including Bulk Transactions) to be disabled by environment variable (`STAC_FASTAPI_ENABLE_TRANSACTIONS`) at deployment time. This allows the stac fastapi instance to be defined as either read-only (transaction endpoints disabled) or read-write (with all transactions endpoints enabled).
This has been tested both locally and on the cluster by using the eodhp-stac-fastapi-0.1.7-test-2 image.
This PR also includes some updates import ordering using isort.