### PR TITLE
Bugfix/remove undefined variable and fix next url

### DIFF
--- a/stac_fastapi/core/stac_fastapi/core/core.py
+++ b/stac_fastapi/core/stac_fastapi/core/core.py
@@ -1390,7 +1390,7 @@ class EsAsyncDiscoverySearchClient(AsyncDiscoverySearchClient):
                 search=search,
                 limit=limit,
                 token=token,
-                sort=None,  # use dafault sort for the minute
+                sort=None,  # use default sort for the minute
                 base_url=base_url,
             )
         )

--- a/stac_fastapi/core/stac_fastapi/core/core.py
+++ b/stac_fastapi/core/stac_fastapi/core/core.py
@@ -1389,9 +1389,8 @@ class EsAsyncDiscoverySearchClient(AsyncDiscoverySearchClient):
             await self.database.execute_discovery_search(
                 search=search,
                 limit=limit,
-                token=None,
-                sort=sort,
-
+                token=token,
+                sort=None,  # use dafault sort for the minute
                 base_url=base_url,
             )
         )

--- a/stac_fastapi/core/stac_fastapi/core/models/links.py
+++ b/stac_fastapi/core/stac_fastapi/core/models/links.py
@@ -118,9 +118,14 @@ class PagingLinks(BaseLinks):
     def link_next(self) -> Optional[Dict[str, Any]]:
         """Create link for next page."""
         if self.next is not None:
+            # Need to generate next link by combining the current url, including base url, with the next token
+            parsed_url = urlparse(self.url)
+            netloc = parsed_url.netloc
+            query_url = self.url.split(netloc)[1]
+            new_url = self.resolve(query_url)
             method = self.request.method
             if method == "GET":
-                href = merge_params(self.url, {"token": self.next})
+                href = merge_params(new_url, {"token": self.next})
                 link = dict(
                     rel=Relations.next.value,
                     type=MimeTypes.json.value,


### PR DESCRIPTION
Small bugfix to remove unassigned variable which was causing issues on the cluster and added in variable to avoid ruff warning.
Also updated next link creation logic, as the previous logic was failing on the cluster.