### PR TITLE
Bugfix/eodhp 277 use stac fastapi endpoints with stac browser

### DIFF
--- a/stac_fastapi/core/stac_fastapi/core/core.py
+++ b/stac_fastapi/core/stac_fastapi/core/core.py
@@ -271,10 +271,10 @@ class CoreClient(AsyncBaseCoreClient):
                     base_url=base_url,
                 )
             )
-
-        collections, next_token = await self.database.get_all_collections(
-            token=token, limit=limit, base_url=base_url
-        )
+        else:
+            collections, next_token = await self.database.get_all_collections(
+                token=token, limit=limit, base_url=base_url
+            )
 
         links = [
             {"rel": Relations.root.value, "type": MimeTypes.json, "href": base_url},

--- a/stac_fastapi/core/stac_fastapi/core/core.py
+++ b/stac_fastapi/core/stac_fastapi/core/core.py
@@ -1255,11 +1255,11 @@ class TransactionsClient(AsyncBaseTransactionsClient):
         """
 
         base_url = str(kwargs["request"].base_url)
-        catalog = self.database.catalog_serializer.stac_to_db(catalog=catalog, base_url=base_url, conformance_classes=self.conformance_classes())
+        catalog = self.database.catalog_serializer.stac_to_db(catalog=catalog, base_url=base_url)
 
         await self.database.create_catalog(catalog=catalog)
 
-        return CatalogSerializer.db_to_stac(catalog=catalog, base_url=base_url)
+        return CatalogSerializer.db_to_stac(catalog=catalog, base_url=base_url, conformance_classes=None) # not needed here: conformance_classes=self.conformance_classes()) conformance_classes=self.conformance_classes())
 
     @overrides
     async def update_catalog(
@@ -1285,10 +1285,10 @@ class TransactionsClient(AsyncBaseTransactionsClient):
         """
         base_url = str(kwargs["request"].base_url)
 
-        catalog = self.database.catalog_serializer.stac_to_db(catalog=catalog, base_url=base_url, conformance_classes=self.conformance_classes())
+        catalog = self.database.catalog_serializer.stac_to_db(catalog=catalog, base_url=base_url)
         await self.database.update_catalog(catalog_id=catalog_id, catalog=catalog)
 
-        return CatalogSerializer.db_to_stac(catalog=catalog, base_url=base_url)
+        return CatalogSerializer.db_to_stac(catalog=catalog, base_url=base_url, conformance_classes=None) # not needed here: conformance_classes=self.conformance_classes())
 
     @overrides
     async def delete_catalog(

--- a/stac_fastapi/core/stac_fastapi/core/core.py
+++ b/stac_fastapi/core/stac_fastapi/core/core.py
@@ -1,6 +1,7 @@
 """Item crud client."""
 
 import logging
+import os
 import re
 from datetime import datetime as datetime_type
 from datetime import timezone
@@ -64,6 +65,8 @@ from stac_fastapi.types.stac import (
 logger = logging.getLogger(__name__)
 
 NumType = Union[float, int]
+
+NUMBER_OF_CATALOG_COLLECTIONS = os.getenv("NUMBER_OF_CATALOG_COLLECTIONS", 100)
 
 
 @attr.s
@@ -369,7 +372,10 @@ class CoreClient(AsyncBaseCoreClient):
         catalog = await self.database.find_catalog(catalog_id=catalog_id)
         # Assume at most 100 collections in a catalog for the time being, may need to increase
         collections, _ = await self.database.get_catalog_collections(
-            catalog_ids=[catalog_id], base_url=base_url, limit=100, token=None
+            catalog_ids=[catalog_id],
+            base_url=base_url,
+            limit=NUMBER_OF_CATALOG_COLLECTIONS,
+            token=None,
         )
         return self.catalog_serializer.db_to_stac(
             catalog=catalog,

--- a/stac_fastapi/core/stac_fastapi/core/core.py
+++ b/stac_fastapi/core/stac_fastapi/core/core.py
@@ -1634,6 +1634,22 @@ class EsAsyncDiscoverySearchClient(AsyncDiscoverySearchClient):
         default=CatalogCollectionSerializer
     )
 
+    extensions: List[ApiExtension] = attr.ib(default=attr.Factory(list))
+    base_conformance_classes: List[str] = attr.ib(
+        factory=lambda: BASE_CONFORMANCE_CLASSES
+    )
+
+    def conformance_classes(self) -> List[str]:
+        """Generate conformance classes by adding extension conformance to base
+        conformance classes."""
+        base_conformance_classes = self.base_conformance_classes.copy()
+
+        for extension in self.extensions:
+            extension_classes = getattr(extension, "conformance_classes", [])
+            base_conformance_classes.extend(extension_classes)
+
+        return list(set(base_conformance_classes))
+
     async def post_discovery_search(
         self,
         search_request: BaseDiscoverySearchPostRequest,

--- a/stac_fastapi/core/stac_fastapi/core/models/links.py
+++ b/stac_fastapi/core/stac_fastapi/core/models/links.py
@@ -120,7 +120,7 @@ class PagingLinks(BaseLinks):
         if self.next is not None:
             # Need to generate next link by combining the current url, including base url, with the next token
             parsed_url = urlparse(self.url)
-            netloc = parsed_url.netloc + "/"
+            netloc = urljoin(parsed_url.netloc, "/")
             query_url = self.url.split(netloc)[1]
             new_url = self.resolve(query_url)
             method = self.request.method

--- a/stac_fastapi/core/stac_fastapi/core/models/links.py
+++ b/stac_fastapi/core/stac_fastapi/core/models/links.py
@@ -118,9 +118,14 @@ class PagingLinks(BaseLinks):
     def link_next(self) -> Optional[Dict[str, Any]]:
         """Create link for next page."""
         if self.next is not None:
+            # Need to generate next link by combining the current url, including base url, with the next token
+            parsed_url = urlparse(self.url)
+            netloc = parsed_url.netloc + "/"
+            query_url = self.url.split(netloc)[1]
+            new_url = self.resolve(query_url)
             method = self.request.method
             if method == "GET":
-                href = merge_params(self.url, {"token": self.next})
+                href = merge_params(new_url, {"token": self.next})
                 link = dict(
                     rel=Relations.next.value,
                     type=MimeTypes.json.value,

--- a/stac_fastapi/core/stac_fastapi/core/serializers.py
+++ b/stac_fastapi/core/stac_fastapi/core/serializers.py
@@ -253,7 +253,7 @@ class CatalogSerializer(Serializer):
         for link in catalog_links:
             link_rels.append(link["rel"])
             if link["rel"] == "data":
-                link["href"] = urljoin(base_url + f"catalogs/{catalog_id}/collections")
+                link["href"] = urljoin(base_url, f"catalogs/{catalog_id}/collections")
                 break
             elif link["rel"] == "conformance":
                 link["href"] = urljoin(base_url, "conformance")
@@ -297,7 +297,7 @@ class CatalogSerializer(Serializer):
                 {
                     "rel": "self",
                     "type": "application/json",
-                    "href": urljoin(base_url + f"catalogs/{catalog_id}"),
+                    "href": urljoin(base_url, f"catalogs/{catalog_id}"),
                 }
             )
         if "search_post" not in link_rels:
@@ -400,27 +400,27 @@ class CatalogCollectionSerializer(Serializer):
         for link in catalog_links:
             link_rels.append(link["rel"])
             if link["rel"] == "data":
-                link["href"] = base_url + "catalogs/" + catalog_id + "/collections"
+                link["href"] = urljoin(base_url, f"catalogs/{catalog_id}/collections")
                 break
             elif link["rel"] == "conformance":
-                link["href"] = base_url + "conformance"
+                link["href"] = urljoin(base_url, "conformance")
             elif link["rel"] == "root":
-                link["href"] = base_url + "catalogs/" + catalog_id
+                link["href"] = urljoin(base_url, f"catalogs/{catalog_id}")
             elif link["rel"] == "self":
-                link["href"] = base_url + "catalogs/" + catalog_id
+                link["href"] = urljoin(base_url, f"catalogs/{catalog_id}")
             elif link["rel"] == "search":
                 if link["method"] == "POST":
                     link_rels.append("search_post")
                 elif link["method"] == "GET":
                     link_rels.append("search_get")
-                link["href"] = base_url + "catalogs/" + catalog_id + "/search"
+                link["href"] = urljoin(base_url, f"catalogs/{catalog_id}/search")
 
         if "data" not in link_rels:
             catalog_links.append(
                 {
                     "rel": "data",
                     "type": "application/json",
-                    "href": base_url + "catalogs/" + catalog_id + "/collections",
+                    "href": urljoin(base_url, f"catalogs/{catalog_id}/collections"),
                 }
             )
         if "conformance" not in link_rels:
@@ -428,7 +428,7 @@ class CatalogCollectionSerializer(Serializer):
                 {
                     "rel": "conformance",
                     "type": "application/json",
-                    "href": base_url + "conformance",
+                    "href": urljoin(base_url, "conformance"),
                 }
             )
         if "root" not in link_rels:
@@ -436,7 +436,7 @@ class CatalogCollectionSerializer(Serializer):
                 {
                     "rel": "root",
                     "type": "application/json",
-                    "href": base_url + "catalogs/" + catalog_id,
+                    "href": urljoin(base_url, f"catalogs/{catalog_id}"),
                 }
             )
         if "self" not in link_rels:
@@ -444,7 +444,7 @@ class CatalogCollectionSerializer(Serializer):
                 {
                     "rel": "self",
                     "type": "application/json",
-                    "href": base_url + "catalogs/" + catalog_id,
+                    "href": urljoin(base_url, f"catalogs/{catalog_id}"),
                 }
             )
         if "search_post" not in link_rels:
@@ -452,7 +452,7 @@ class CatalogCollectionSerializer(Serializer):
                 {
                     "rel": "search",
                     "type": "application/json",
-                    "href": base_url + "catalogs/" + catalog_id + "/search",
+                    "href": urljoin(base_url, f"catalogs/{catalog_id}/search"),
                     "method": "POST",
                 }
             )
@@ -461,7 +461,7 @@ class CatalogCollectionSerializer(Serializer):
                 {
                     "rel": "search",
                     "type": "application/geo+json",
-                    "href": base_url + "catalogs/" + catalog_id + "/search",
+                    "href": urljoin(base_url, f"catalogs/{catalog_id}/search"),
                     "method": "GET",
                 }
             )
@@ -471,11 +471,9 @@ class CatalogCollectionSerializer(Serializer):
             child_link = {
                 "rel": "child",
                 "type": "application/json",
-                "href": base_url
-                + "catalogs/"
-                + catalog_id
-                + "/collections/"
-                + collection_id,
+                "href": urljoin(
+                    base_url, f"catalogs/{catalog_id}/collections/{collection_id}"
+                ),
             }
             catalog_links.append(child_link)
 

--- a/stac_fastapi/core/stac_fastapi/core/serializers.py
+++ b/stac_fastapi/core/stac_fastapi/core/serializers.py
@@ -3,6 +3,7 @@
 import abc
 from copy import deepcopy
 from typing import Any
+from urllib.parse import urljoin
 
 import attr
 
@@ -246,51 +247,51 @@ class CatalogSerializer(Serializer):
         for link in catalog_links:
             link_rels.append(link["rel"])
             if link["rel"] == "data":
-                link["href"] = base_url + "catalogs/"+ catalog_id + "/collections"
+                link["href"] = urljoin(base_url + f"catalogs/{catalog_id}/collections")
                 break
             elif link["rel"] == "conformance":
-                link["href"] = base_url + "conformance"
+                link["href"] = urljoin(base_url, f"conformance")
             elif link["rel"] == "root":
-                link["href"] = base_url + "catalogs/"+ catalog_id
+                link["href"] = urljoin(base_url, f"catalogs/{catalog_id}")
             elif link["rel"] == "self":
-                link["href"] = base_url + "catalogs/"+ catalog_id
+                link["href"] = urljoin(base_url, f"catalogs/{catalog_id}")
             elif link["rel"] == "search":
                 if link["method"] == "POST":
                     link_rels.append("search_post")
                 elif link["method"] == "GET":
                     link_rels.append("search_get")
-                link["href"] = base_url + "catalogs/"+ catalog_id + "/search"
+                link["href"] = urljoin(base_url, f"catalogs/{catalog_id}/search")
 
         if "data" not in link_rels:
             catalog_links.append({"rel": "data",
                                     "type": "application/json",
-                                    "href": base_url + "catalogs/"+ catalog_id + "/collections"
+                                    "href": urljoin(base_url, f"catalogs/{catalog_id}/collections")
                                     })
         if "conformance" not in link_rels:
             catalog_links.append({"rel": "conformance",
                                     "type": "application/json",
-                                    "href": base_url + "conformance"
+                                    "href": urljoin(base_url, "conformance")
                                     })
         if "root" not in link_rels:
             catalog_links.append({"rel": "root",
                                     "type": "application/json",
-                                    "href": base_url + "catalogs/"+ catalog_id
+                                    "href": urljoin(base_url, f"catalogs/{catalog_id}")
                                     })
         if "self" not in link_rels:
             catalog_links.append({"rel": "self",
                                     "type": "application/json",
-                                    "href": base_url + "catalogs/"+ catalog_id
+                                    "href": urljoin(base_url + f"catalogs/{catalog_id}")
                                     })
         if "search_post" not in link_rels:
             catalog_links.append({"rel": "search",
                                     "type": "application/json",
-                                    "href": base_url + "catalogs/"+ catalog_id + "/search",
+                                    "href": urljoin(base_url, f"catalogs/{catalog_id}/search"),
                                     "method": "POST"
                                     })
         if "search_get" not in link_rels:
             catalog_links.append({"rel": "search",
                                     "type": "application/geo+json",
-                                    "href": base_url + "catalogs/"+ catalog_id + "/search",
+                                    "href": urljoin(base_url, f"catalogs/{catalog_id}/search"),
                                     "method": "GET"
                                     })
 
@@ -299,7 +300,7 @@ class CatalogSerializer(Serializer):
             child_link = {
                 "rel": "child",
                 "type": "application/json",
-                "href": base_url + "catalogs/"+ catalog_id + "/collections/" + collection_id
+                "href": urljoin(base_url, f"catalogs/{catalog_id}/collections/{collection_id}")
             }
             catalog_links.append(child_link)
 

--- a/stac_fastapi/core/stac_fastapi/core/serializers.py
+++ b/stac_fastapi/core/stac_fastapi/core/serializers.py
@@ -208,7 +208,13 @@ class CatalogSerializer(Serializer):
         return catalog
 
     @classmethod
-    def db_to_stac(cls, catalog: dict, base_url: str, collections: list = [], conformance_classes: list = []) -> stac_types.Catalog:
+    def db_to_stac(
+        cls,
+        catalog: dict,
+        base_url: str,
+        collections: list = [],
+        conformance_classes: list = [],
+    ) -> stac_types.Catalog:
         """Transform database model to STAC catalog.
 
         Args:
@@ -241,7 +247,7 @@ class CatalogSerializer(Serializer):
         original_links = catalog.get("links")
         if original_links:
             catalog_links += resolve_links(original_links, base_url)
-        
+
         # The following link should be rewritten for collections within this catalog
         link_rels = []
         for link in catalog_links:
@@ -250,7 +256,7 @@ class CatalogSerializer(Serializer):
                 link["href"] = urljoin(base_url + f"catalogs/{catalog_id}/collections")
                 break
             elif link["rel"] == "conformance":
-                link["href"] = urljoin(base_url, f"conformance")
+                link["href"] = urljoin(base_url, "conformance")
             elif link["rel"] == "root":
                 link["href"] = urljoin(base_url, f"catalogs/{catalog_id}")
             elif link["rel"] == "self":
@@ -263,44 +269,64 @@ class CatalogSerializer(Serializer):
                 link["href"] = urljoin(base_url, f"catalogs/{catalog_id}/search")
 
         if "data" not in link_rels:
-            catalog_links.append({"rel": "data",
-                                    "type": "application/json",
-                                    "href": urljoin(base_url, f"catalogs/{catalog_id}/collections")
-                                    })
+            catalog_links.append(
+                {
+                    "rel": "data",
+                    "type": "application/json",
+                    "href": urljoin(base_url, f"catalogs/{catalog_id}/collections"),
+                }
+            )
         if "conformance" not in link_rels:
-            catalog_links.append({"rel": "conformance",
-                                    "type": "application/json",
-                                    "href": urljoin(base_url, "conformance")
-                                    })
+            catalog_links.append(
+                {
+                    "rel": "conformance",
+                    "type": "application/json",
+                    "href": urljoin(base_url, "conformance"),
+                }
+            )
         if "root" not in link_rels:
-            catalog_links.append({"rel": "root",
-                                    "type": "application/json",
-                                    "href": urljoin(base_url, f"catalogs/{catalog_id}")
-                                    })
+            catalog_links.append(
+                {
+                    "rel": "root",
+                    "type": "application/json",
+                    "href": urljoin(base_url, f"catalogs/{catalog_id}"),
+                }
+            )
         if "self" not in link_rels:
-            catalog_links.append({"rel": "self",
-                                    "type": "application/json",
-                                    "href": urljoin(base_url + f"catalogs/{catalog_id}")
-                                    })
+            catalog_links.append(
+                {
+                    "rel": "self",
+                    "type": "application/json",
+                    "href": urljoin(base_url + f"catalogs/{catalog_id}"),
+                }
+            )
         if "search_post" not in link_rels:
-            catalog_links.append({"rel": "search",
-                                    "type": "application/json",
-                                    "href": urljoin(base_url, f"catalogs/{catalog_id}/search"),
-                                    "method": "POST"
-                                    })
+            catalog_links.append(
+                {
+                    "rel": "search",
+                    "type": "application/json",
+                    "href": urljoin(base_url, f"catalogs/{catalog_id}/search"),
+                    "method": "POST",
+                }
+            )
         if "search_get" not in link_rels:
-            catalog_links.append({"rel": "search",
-                                    "type": "application/geo+json",
-                                    "href": urljoin(base_url, f"catalogs/{catalog_id}/search"),
-                                    "method": "GET"
-                                    })
+            catalog_links.append(
+                {
+                    "rel": "search",
+                    "type": "application/geo+json",
+                    "href": urljoin(base_url, f"catalogs/{catalog_id}/search"),
+                    "method": "GET",
+                }
+            )
 
         for collection in collections:
             collection_id = collection.get("id")
             child_link = {
                 "rel": "child",
                 "type": "application/json",
-                "href": urljoin(base_url, f"catalogs/{catalog_id}/collections/{collection_id}")
+                "href": urljoin(
+                    base_url, f"catalogs/{catalog_id}/collections/{collection_id}"
+                ),
             }
             catalog_links.append(child_link)
 
@@ -329,7 +355,13 @@ class CatalogCollectionSerializer(Serializer):
         raise NotImplementedError
 
     @classmethod
-    def catalog_db_to_stac(cls, catalog: dict, base_url: str, collections: list = [], conformance_classes: list = []) -> stac_types.Catalog:
+    def catalog_db_to_stac(
+        cls,
+        catalog: dict,
+        base_url: str,
+        collections: list = [],
+        conformance_classes: list = [],
+    ) -> stac_types.Catalog:
         """Transform database model to STAC catalog.
 
         Args:
@@ -362,66 +394,88 @@ class CatalogCollectionSerializer(Serializer):
         original_links = catalog.get("links")
         if original_links:
             catalog_links += resolve_links(original_links, base_url)
-        
+
         # The following link should be rewritten for collections within this catalog
         link_rels = []
         for link in catalog_links:
             link_rels.append(link["rel"])
             if link["rel"] == "data":
-                link["href"] = base_url + "catalogs/"+ catalog_id + "/collections"
+                link["href"] = base_url + "catalogs/" + catalog_id + "/collections"
                 break
             elif link["rel"] == "conformance":
                 link["href"] = base_url + "conformance"
             elif link["rel"] == "root":
-                link["href"] = base_url + "catalogs/"+ catalog_id
+                link["href"] = base_url + "catalogs/" + catalog_id
             elif link["rel"] == "self":
-                link["href"] = base_url + "catalogs/"+ catalog_id
+                link["href"] = base_url + "catalogs/" + catalog_id
             elif link["rel"] == "search":
                 if link["method"] == "POST":
                     link_rels.append("search_post")
                 elif link["method"] == "GET":
                     link_rels.append("search_get")
-                link["href"] = base_url + "catalogs/"+ catalog_id + "/search"
+                link["href"] = base_url + "catalogs/" + catalog_id + "/search"
 
         if "data" not in link_rels:
-            catalog_links.append({"rel": "data",
-                                    "type": "application/json",
-                                    "href": base_url + "catalogs/"+ catalog_id + "/collections"
-                                    })
+            catalog_links.append(
+                {
+                    "rel": "data",
+                    "type": "application/json",
+                    "href": base_url + "catalogs/" + catalog_id + "/collections",
+                }
+            )
         if "conformance" not in link_rels:
-            catalog_links.append({"rel": "conformance",
-                                    "type": "application/json",
-                                    "href": base_url + "conformance"
-                                    })
+            catalog_links.append(
+                {
+                    "rel": "conformance",
+                    "type": "application/json",
+                    "href": base_url + "conformance",
+                }
+            )
         if "root" not in link_rels:
-            catalog_links.append({"rel": "root",
-                                    "type": "application/json",
-                                    "href": base_url + "catalogs/"+ catalog_id
-                                    })
+            catalog_links.append(
+                {
+                    "rel": "root",
+                    "type": "application/json",
+                    "href": base_url + "catalogs/" + catalog_id,
+                }
+            )
         if "self" not in link_rels:
-            catalog_links.append({"rel": "self",
-                                    "type": "application/json",
-                                    "href": base_url + "catalogs/"+ catalog_id
-                                    })
+            catalog_links.append(
+                {
+                    "rel": "self",
+                    "type": "application/json",
+                    "href": base_url + "catalogs/" + catalog_id,
+                }
+            )
         if "search_post" not in link_rels:
-            catalog_links.append({"rel": "search",
-                                    "type": "application/json",
-                                    "href": base_url + "catalogs/"+ catalog_id + "/search",
-                                    "method": "POST"
-                                    })
+            catalog_links.append(
+                {
+                    "rel": "search",
+                    "type": "application/json",
+                    "href": base_url + "catalogs/" + catalog_id + "/search",
+                    "method": "POST",
+                }
+            )
         if "search_get" not in link_rels:
-            catalog_links.append({"rel": "search",
-                                    "type": "application/geo+json",
-                                    "href": base_url + "catalogs/"+ catalog_id + "/search",
-                                    "method": "GET"
-                                    })
+            catalog_links.append(
+                {
+                    "rel": "search",
+                    "type": "application/geo+json",
+                    "href": base_url + "catalogs/" + catalog_id + "/search",
+                    "method": "GET",
+                }
+            )
 
         for collection in collections:
             collection_id = collection.get("id")
             child_link = {
                 "rel": "child",
                 "type": "application/json",
-                "href": base_url + "catalogs/"+ catalog_id + "/collections/" + collection_id
+                "href": base_url
+                + "catalogs/"
+                + catalog_id
+                + "/collections/"
+                + collection_id,
             }
             catalog_links.append(child_link)
 
@@ -478,7 +532,12 @@ class CatalogCollectionSerializer(Serializer):
 
     @classmethod
     def db_to_stac(
-        cls, data: dict, base_url: str, catalog_id: str = None, collections: list = [], conformance_classes: list = [] 
+        cls,
+        data: dict,
+        base_url: str,
+        catalog_id: str = None,
+        collections: list = [],
+        conformance_classes: list = [],
     ) -> stac_types.Collection:
         """Transform database model to STAC catalog or collection.
 
@@ -495,4 +554,6 @@ class CatalogCollectionSerializer(Serializer):
                 catalog_id=catalog_id, collection=data, base_url=base_url
             )
         elif data["type"] == "Catalog":
-            return cls.catalog_db_to_stac(data, base_url, collections, conformance_classes)
+            return cls.catalog_db_to_stac(
+                data, base_url, collections, conformance_classes
+            )

--- a/stac_fastapi/core/stac_fastapi/core/serializers.py
+++ b/stac_fastapi/core/stac_fastapi/core/serializers.py
@@ -241,8 +241,10 @@ class CatalogSerializer(Serializer):
         if original_links:
             catalog_links += resolve_links(original_links, base_url)
         
-        # The data link should be rewritten for collections within this catalog
+        # The following link should be rewritten for collections within this catalog
+        link_rels = []
         for link in catalog_links:
+            link_rels.append(link["rel"])
             if link["rel"] == "data":
                 link["href"] = base_url + "catalogs/"+ catalog_id + "/collections"
                 break
@@ -253,13 +255,44 @@ class CatalogSerializer(Serializer):
             elif link["rel"] == "self":
                 link["href"] = base_url + "catalogs/"+ catalog_id
             elif link["rel"] == "search":
+                if link["method"] == "POST":
+                    link_rels.append("search_post")
+                elif link["method"] == "GET":
+                    link_rels.append("search_get")
                 link["href"] = base_url + "catalogs/"+ catalog_id + "/search"
 
-        else:
+        if "data" not in link_rels:
             catalog_links.append({"rel": "data",
-                                  "type": "application/json",
-                                  "href": base_url + "catalogs/"+ catalog_id + "/collections"
-                                  })
+                                    "type": "application/json",
+                                    "href": base_url + "catalogs/"+ catalog_id + "/collections"
+                                    })
+        if "conformance" not in link_rels:
+            catalog_links.append({"rel": "conformance",
+                                    "type": "application/json",
+                                    "href": base_url + "conformance"
+                                    })
+        if "root" not in link_rels:
+            catalog_links.append({"rel": "root",
+                                    "type": "application/json",
+                                    "href": base_url + "catalogs/"+ catalog_id
+                                    })
+        if "self" not in link_rels:
+            catalog_links.append({"rel": "self",
+                                    "type": "application/json",
+                                    "href": base_url + "catalogs/"+ catalog_id
+                                    })
+        if "search_post" not in link_rels:
+            catalog_links.append({"rel": "search",
+                                    "type": "application/json",
+                                    "href": base_url + "catalogs/"+ catalog_id + "/search",
+                                    "method": "POST"
+                                    })
+        if "search_get" not in link_rels:
+            catalog_links.append({"rel": "search",
+                                    "type": "application/geo+json",
+                                    "href": base_url + "catalogs/"+ catalog_id + "/search",
+                                    "method": "GET"
+                                    })
 
         for collection in collections:
             collection_id = collection.get("id")

--- a/stac_fastapi/core/stac_fastapi/core/serializers.py
+++ b/stac_fastapi/core/stac_fastapi/core/serializers.py
@@ -328,7 +328,7 @@ class CatalogCollectionSerializer(Serializer):
         raise NotImplementedError
 
     @classmethod
-    def catalog_db_to_stac(cls, catalog: dict, base_url: str) -> stac_types.Catalog:
+    def catalog_db_to_stac(cls, catalog: dict, base_url: str, collections: list = [], conformance_classes: list = []) -> stac_types.Catalog:
         """Transform database model to STAC catalog.
 
         Args:
@@ -349,6 +349,9 @@ class CatalogCollectionSerializer(Serializer):
         catalog.setdefault("title", "")
         catalog.setdefault("description", "")
 
+        # Set conformance for catalog
+        catalog.update({"conformsTo": conformance_classes})
+
         # Create the collection links using CatalogLinks
         catalog_links = CatalogLinks(
             catalog_id=catalog_id, base_url=base_url
@@ -358,6 +361,69 @@ class CatalogCollectionSerializer(Serializer):
         original_links = catalog.get("links")
         if original_links:
             catalog_links += resolve_links(original_links, base_url)
+        
+        # The following link should be rewritten for collections within this catalog
+        link_rels = []
+        for link in catalog_links:
+            link_rels.append(link["rel"])
+            if link["rel"] == "data":
+                link["href"] = base_url + "catalogs/"+ catalog_id + "/collections"
+                break
+            elif link["rel"] == "conformance":
+                link["href"] = base_url + "conformance"
+            elif link["rel"] == "root":
+                link["href"] = base_url + "catalogs/"+ catalog_id
+            elif link["rel"] == "self":
+                link["href"] = base_url + "catalogs/"+ catalog_id
+            elif link["rel"] == "search":
+                if link["method"] == "POST":
+                    link_rels.append("search_post")
+                elif link["method"] == "GET":
+                    link_rels.append("search_get")
+                link["href"] = base_url + "catalogs/"+ catalog_id + "/search"
+
+        if "data" not in link_rels:
+            catalog_links.append({"rel": "data",
+                                    "type": "application/json",
+                                    "href": base_url + "catalogs/"+ catalog_id + "/collections"
+                                    })
+        if "conformance" not in link_rels:
+            catalog_links.append({"rel": "conformance",
+                                    "type": "application/json",
+                                    "href": base_url + "conformance"
+                                    })
+        if "root" not in link_rels:
+            catalog_links.append({"rel": "root",
+                                    "type": "application/json",
+                                    "href": base_url + "catalogs/"+ catalog_id
+                                    })
+        if "self" not in link_rels:
+            catalog_links.append({"rel": "self",
+                                    "type": "application/json",
+                                    "href": base_url + "catalogs/"+ catalog_id
+                                    })
+        if "search_post" not in link_rels:
+            catalog_links.append({"rel": "search",
+                                    "type": "application/json",
+                                    "href": base_url + "catalogs/"+ catalog_id + "/search",
+                                    "method": "POST"
+                                    })
+        if "search_get" not in link_rels:
+            catalog_links.append({"rel": "search",
+                                    "type": "application/geo+json",
+                                    "href": base_url + "catalogs/"+ catalog_id + "/search",
+                                    "method": "GET"
+                                    })
+
+        for collection in collections:
+            collection_id = collection.get("id")
+            child_link = {
+                "rel": "child",
+                "type": "application/json",
+                "href": base_url + "catalogs/"+ catalog_id + "/collections/" + collection_id
+            }
+            catalog_links.append(child_link)
+
         catalog["links"] = catalog_links
 
         # Return the stac_types.Collection object
@@ -411,7 +477,7 @@ class CatalogCollectionSerializer(Serializer):
 
     @classmethod
     def db_to_stac(
-        cls, data: dict, base_url: str, catalog_id: str = None
+        cls, data: dict, base_url: str, catalog_id: str = None, collections: list = [], conformance_classes: list = [] 
     ) -> stac_types.Collection:
         """Transform database model to STAC catalog or collection.
 
@@ -428,4 +494,4 @@ class CatalogCollectionSerializer(Serializer):
                 catalog_id=catalog_id, collection=data, base_url=base_url
             )
         elif data["type"] == "Catalog":
-            return cls.catalog_db_to_stac(data, base_url)
+            return cls.catalog_db_to_stac(data, base_url, collections, conformance_classes)

--- a/stac_fastapi/core/stac_fastapi/core/types/core.py
+++ b/stac_fastapi/core/stac_fastapi/core/types/core.py
@@ -11,7 +11,7 @@ from stac_fastapi.core.base_database_logic import BaseDatabaseLogic
 from stac_fastapi.types import stac as stac_types
 from stac_fastapi.types.conformance import BASE_CONFORMANCE_CLASSES
 from stac_fastapi.types.extension import ApiExtension
-from stac_fastapi.types.search import BaseSearchPostRequest
+from stac_fastapi.types.search import BaseSearchPostRequest, BaseCatalogSearchPostRequest
 from stac_fastapi.types.stac import Conformance
 
 NumType = Union[float, int]
@@ -234,8 +234,49 @@ class AsyncBaseCoreClient(abc.ABC):
         return Conformance(conformsTo=self.conformance_classes())
 
     @abc.abstractmethod
-    async def post_search(
+    async def post_global_search(
         self, search_request: BaseSearchPostRequest, **kwargs
+    ) -> stac_types.ItemCollection:
+        """Cross catalog search (POST).
+
+        Called with `POST /search`.
+
+        Args:
+            search_request: search request parameters.
+
+        Returns:
+            ItemCollection containing items which match the search criteria.
+        """
+        ...
+
+    @abc.abstractmethod
+    async def get_global_search(
+        self,
+        catalogs: Optional[List[str]] = None,
+        collections: Optional[List[str]] = None,
+        ids: Optional[List[str]] = None,
+        bbox: Optional[List[NumType]] = None,
+        datetime: Optional[Union[str, datetime]] = None,
+        limit: Optional[int] = 10,
+        query: Optional[str] = None,
+        token: Optional[str] = None,
+        fields: Optional[List[str]] = None,
+        sortby: Optional[str] = None,
+        intersects: Optional[str] = None,
+        **kwargs,
+    ) -> stac_types.ItemCollection:
+        """Cross catalog search (GET).
+
+        Called with `GET /search`.
+
+        Returns:
+            ItemCollection containing items which match the search criteria.
+        """
+        ...
+
+    @abc.abstractmethod
+    async def post_search(
+        self, catalog_id: str, search_request: BaseCatalogSearchPostRequest, **kwargs
     ) -> stac_types.ItemCollection:
         """Cross catalog search (POST).
 
@@ -252,6 +293,7 @@ class AsyncBaseCoreClient(abc.ABC):
     @abc.abstractmethod
     async def get_search(
         self,
+        catalog_id: str,
         collections: Optional[List[str]] = None,
         ids: Optional[List[str]] = None,
         bbox: Optional[List[NumType]] = None,

--- a/stac_fastapi/core/stac_fastapi/core/types/core.py
+++ b/stac_fastapi/core/stac_fastapi/core/types/core.py
@@ -11,7 +11,10 @@ from stac_fastapi.core.base_database_logic import BaseDatabaseLogic
 from stac_fastapi.types import stac as stac_types
 from stac_fastapi.types.conformance import BASE_CONFORMANCE_CLASSES
 from stac_fastapi.types.extension import ApiExtension
-from stac_fastapi.types.search import BaseSearchPostRequest, BaseCatalogSearchPostRequest
+from stac_fastapi.types.search import (
+    BaseCatalogSearchPostRequest,
+    BaseSearchPostRequest,
+)
 from stac_fastapi.types.stac import Conformance
 
 NumType = Union[float, int]

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/app.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/app.py
@@ -2,17 +2,18 @@
 
 import os
 
-from stac_fastapi.api.app import StacApi
 from pydantic import BaseModel
+
+from stac_fastapi.api.app import StacApi
 from stac_fastapi.api.models import (
-    create_get_request_model,
-    create_post_request_model,
     EmptyRequest,
-    create_get_collections_request_model,
-    create_post_collections_request_model,
     create_get_catalog_request_model,
+    create_get_collections_request_model,
+    create_get_request_model,
     create_post_catalog_full_request_model,
     create_post_catalog_request_model,
+    create_post_collections_request_model,
+    create_post_request_model,
 )
 from stac_fastapi.core.core import (
     BulkTransactionsClient,
@@ -41,11 +42,11 @@ from stac_fastapi.extensions.core import (
     TokenPaginationExtension,
     TransactionExtension,
 )
-from stac_fastapi.types.search import (
-    BaseCatalogSearchPostRequest,
-    BaseCatalogSearchGetRequest,
-)
 from stac_fastapi.extensions.third_party import BulkTransactionExtension
+from stac_fastapi.types.search import (
+    BaseCatalogSearchGetRequest,
+    BaseCatalogSearchPostRequest,
+)
 
 settings = ElasticsearchSettings()
 session = Session.create_from_settings(settings)
@@ -102,11 +103,17 @@ post_request_model = create_post_request_model(extensions)
 get_request_model = create_get_request_model(extensions)
 
 # Includes catalog_id as a path attribute
-catalog_post_full_request_model = create_post_catalog_full_request_model(extensions=extensions, base_model=BaseCatalogSearchPostRequest)
+catalog_post_full_request_model = create_post_catalog_full_request_model(
+    extensions=extensions, base_model=BaseCatalogSearchPostRequest
+)
 # Does not include catalog_id as a path attribute
-catalog_post_request_model = create_post_catalog_request_model(extensions=extensions, base_model=BaseCatalogSearchPostRequest)
+catalog_post_request_model = create_post_catalog_request_model(
+    extensions=extensions, base_model=BaseCatalogSearchPostRequest
+)
 
-catalog_get_request_model = create_get_catalog_request_model(extensions=extensions, base_model=BaseCatalogSearchGetRequest)
+catalog_get_request_model = create_get_catalog_request_model(
+    extensions=extensions, base_model=BaseCatalogSearchGetRequest
+)
 
 # TODO: combine into single create_post/get_request_model function
 # could add another parameter here for the model name e.g. "CollectionsGetRequest" to combine
@@ -116,7 +123,8 @@ collections_post_request_model = create_post_collections_request_model([], BaseM
 
 # Add discovery search here as it requires all other extensions to be passed to it for conformance classes to be identified
 discovery_search_extension = DiscoverySearchExtension(
-    client=EsAsyncDiscoverySearchClient(database=database_logic, extensions=extensions),)
+    client=EsAsyncDiscoverySearchClient(database=database_logic, extensions=extensions),
+)
 discovery_search_extension.conformance_classes.extend(
     ["/catalogues", "/discovery-search"]
 )
@@ -141,7 +149,10 @@ api = StacApi(
     settings=settings,
     extensions=extensions,
     client=CoreClient(
-        database=database_logic, session=session, post_request_model=post_request_model, catalog_post_request_model=catalog_post_request_model
+        database=database_logic,
+        session=session,
+        post_request_model=post_request_model,
+        catalog_post_request_model=catalog_post_request_model,
     ),
     search_get_request_model=get_request_model,
     search_post_request_model=post_request_model,

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/app.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/app.py
@@ -67,13 +67,6 @@ collection_search_extension.conformance_classes.extend(
     ]
 )
 
-discovery_search_extension = DiscoverySearchExtension(
-    client=EsAsyncDiscoverySearchClient(database_logic)
-)
-discovery_search_extension.conformance_classes.extend(
-    ["/catalogues", "/discovery-search"]
-)
-
 extensions = [
     FieldsExtension(),
     QueryExtension(),
@@ -82,7 +75,6 @@ extensions = [
     ContextExtension(),
     collection_search_extension,
     filter_extension,
-    discovery_search_extension,
 ]
 
 # Disable transaction extensions by default
@@ -121,6 +113,15 @@ catalog_get_request_model = create_get_catalog_request_model(extensions=extensio
 # these 'create_request_model' functions with those above
 collections_get_request_model = create_get_collections_request_model([], EmptyRequest)
 collections_post_request_model = create_post_collections_request_model([], BaseModel)
+
+# Add discovery search here as it requires all other extensions to be passed to it for conformance classes to be identified
+discovery_search_extension = DiscoverySearchExtension(
+    client=EsAsyncDiscoverySearchClient(database=database_logic, extensions=extensions),)
+discovery_search_extension.conformance_classes.extend(
+    ["/catalogues", "/discovery-search"]
+)
+
+extensions.append(discovery_search_extension)
 
 # Check if collection search extension is selected
 for extension in extensions:

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
@@ -644,7 +644,11 @@ class DatabaseLogic:
         return collections, next_token
 
     async def get_all_catalogs(
-        self, token: Optional[str], limit: int, base_url: str, conformance_classes: list = [],
+        self,
+        token: Optional[str],
+        limit: int,
+        base_url: str,
+        conformance_classes: list = [],
     ) -> Tuple[List[Dict[str, Any]], Optional[str]]:
         """Retrieve a list of all catalogs from Elasticsearch, supporting pagination.
 
@@ -671,11 +675,16 @@ class DatabaseLogic:
         hits = response["hits"]["hits"]
         catalogs = []
         for hit in hits:
-            collections, _ = await self.get_catalog_collections(catalog_ids=[hit["_source"].get("id")], base_url=base_url, limit=100, token=None)
+            collections, _ = await self.get_catalog_collections(
+                catalog_ids=[hit["_source"].get("id")],
+                base_url=base_url,
+                limit=100,
+                token=None,
+            )
             catalogs.append(
                 self.catalog_serializer.db_to_stac(
-                    catalog=hit["_source"], 
-                    base_url=base_url, 
+                    catalog=hit["_source"],
+                    base_url=base_url,
                     collections=collections,
                     conformance_classes=conformance_classes,
                 )
@@ -1969,7 +1978,12 @@ class DatabaseLogic:
         for hit in hits:
             collections = []
             if hit["_source"]["type"] == "Catalog":
-                collections, _ = await self.get_catalog_collections(catalog_ids=[hit["_source"].get("id")], base_url=base_url, limit=100, token=None)
+                collections, _ = await self.get_catalog_collections(
+                    catalog_ids=[hit["_source"].get("id")],
+                    base_url=base_url,
+                    limit=100,
+                    token=None,
+                )
             data.append(
                 self.catalog_collection_serializer.db_to_stac(
                     data=hit["_source"],

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
@@ -1150,8 +1150,6 @@ class DatabaseLogic:
         elif catalog_ids:
             index_param = indices(catalog_ids=catalog_ids).replace("items_", "items_*")
 
-        print((index_param.split(",")))
-
         search_task = asyncio.create_task(
             self.client.search(
                 index=index_param,

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
@@ -691,14 +691,15 @@ class DatabaseLogic:
         )
 
         for i, result in enumerate(results):
-            catalogs.append(
-                self.catalog_serializer.db_to_stac(
-                    catalog=hits[i]["_source"],
-                    base_url=base_url,
-                    collections=result[0],
-                    conformance_classes=conformance_classes,
+            if not isinstance(result, Exception):
+                catalogs.append(
+                    self.catalog_serializer.db_to_stac(
+                        catalog=hits[i]["_source"],
+                        base_url=base_url,
+                        collections=result[0],
+                        conformance_classes=conformance_classes,
+                    )
                 )
-            )
 
         next_token = None
         if len(hits) == limit:
@@ -2000,15 +2001,16 @@ class DatabaseLogic:
         )
 
         for i, result in enumerate(results):
-            data.append(
-                self.catalog_collection_serializer.db_to_stac(
-                    data=hits[i]["_source"],
-                    base_url=base_url,
-                    catalog_id=hits[i]["_id"].rsplit("|", 1)[-1],
-                    collections=result[0],
-                    conformance_classes=conformance_classes,
+            if not isinstance(result, Exception):
+                data.append(
+                    self.catalog_collection_serializer.db_to_stac(
+                        data=hits[i]["_source"],
+                        base_url=base_url,
+                        catalog_id=hits[i]["_id"].rsplit("|", 1)[-1],
+                        collections=result[0],
+                        conformance_classes=conformance_classes,
+                    )
                 )
-            )
 
         next_token = None
         if hits and (sort_array := hits[-1].get("sort")):


### PR DESCRIPTION
Updated stac-fastapi deployment to better integrate with STAC Browser and Pystac Client (to support CEDA's example Jupyter Notebook). This involves the following changes:
- Updating collection-search extension to extend the built-in `/collections` endpoint rather than adding a new one.
- Adding a POST endpoint for `/collection`
- Adding catalog-specific items searching `/catalogs/{catalog_id}/search` as is required for the Pystac client
  - Requires new pydantic models to be defined allowing other extensions to be included in these endpoints
- Updating catalog serializer to include correct conformance classes, self, children, root, data and search links

Can be tested on dev cluster with test image to confirm endpoints work as expected.