### PR TITLE
Feature/eodhp 280 nested catalog support in stac api

### DIFF
--- a/stac_fastapi/core/stac_fastapi/core/base_database_logic.py
+++ b/stac_fastapi/core/stac_fastapi/core/base_database_logic.py
@@ -33,48 +33,55 @@ class BaseDatabaseLogic(abc.ABC):
 
     @abc.abstractmethod
     async def create_item(
-        self, catalog_id: str, item: Dict, refresh: bool = False
+        self, catalog_path: str, item: Dict, refresh: bool = False
     ) -> None:
         """Create an item in the database."""
         pass
 
     @abc.abstractmethod
     async def delete_item(
-        self, item_id: str, collection_id: str, catalog_id: str, refresh: bool = False
+        self, item_id: str, collection_id: str, catalog_path: str, refresh: bool = False
     ) -> None:
         """Delete an item from the database."""
         pass
 
     @abc.abstractmethod
     async def create_collection(
-        self, catalog_id: str, collection: Dict, refresh: bool = False
+        self, catalog_path: str, collection: Dict, refresh: bool = False
     ) -> None:
         """Create a collection in the database."""
         pass
 
     @abc.abstractmethod
-    async def find_collection(self, catalog_id: str, collection_id: str) -> Dict:
+    async def find_collection(self, catalog_path: str, collection_id: str) -> Dict:
         """Find a collection in the database."""
         pass
 
     @abc.abstractmethod
     async def delete_collection(
-        self, catalog_id: str, collection_id: str, refresh: bool = False
+        self, catalog_path: str, collection_id: str, refresh: bool = False
     ) -> None:
         """Delete a collection from the database."""
         pass
 
     @abc.abstractmethod
-    async def create_catalog(self, catalog: Dict, refresh: bool = False) -> None:
+    async def create_catalog(
+        self, catalog: Dict, catalog_path: Optional[str], refresh: bool = False
+    ) -> None:
         """Create a catalog in the database."""
         pass
 
     @abc.abstractmethod
-    async def find_catalog(self, catalog_id: str) -> Dict:
+    async def create_super_catalog(self, catalog: Dict, refresh: bool = False) -> None:
+        """Create a catalog in the database."""
+        pass
+
+    @abc.abstractmethod
+    async def find_catalog(self, catalog_path: str) -> Dict:
         """Find a catalog in the database."""
         pass
 
     @abc.abstractmethod
-    async def delete_catalog(self, catalog_id: str, refresh: bool = False) -> None:
+    async def delete_catalog(self, catalog_path: str, refresh: bool = False) -> None:
         """Delete a catalog from the database."""
         pass

--- a/stac_fastapi/core/stac_fastapi/core/models/links.py
+++ b/stac_fastapi/core/stac_fastapi/core/models/links.py
@@ -119,13 +119,9 @@ class PagingLinks(BaseLinks):
         """Create link for next page."""
         if self.next is not None:
             # Need to generate next link by combining the current url, including base url, with the next token
-            parsed_url = urlparse(self.url)
-            netloc = urljoin(parsed_url.netloc, "/")
-            query_url = self.url.split(netloc)[1]
-            new_url = self.resolve(query_url)
             method = self.request.method
             if method == "GET":
-                href = merge_params(new_url, {"token": self.next})
+                href = merge_params(self.url, {"token": self.next})
                 link = dict(
                     rel=Relations.next.value,
                     type=MimeTypes.json.value,

--- a/stac_fastapi/core/stac_fastapi/core/serializers.py
+++ b/stac_fastapi/core/stac_fastapi/core/serializers.py
@@ -352,6 +352,8 @@ class CatalogSerializer(Serializer):
 
         # Add child links for contained collections or catalogs
         for collection in collections:
+            if not collection:
+                continue
             collection_id = collection.get("id")
             child_link = {
                 "rel": Relations.child.value,
@@ -361,6 +363,8 @@ class CatalogSerializer(Serializer):
             catalog_links.append(child_link)
 
         for sub_catalog in sub_catalogs:
+            if not sub_catalog:
+                continue
             sub_catalog_id = sub_catalog.get("id")
             child_link = {
                 "rel": Relations.child.value,

--- a/stac_fastapi/core/stac_fastapi/core/types/core.py
+++ b/stac_fastapi/core/stac_fastapi/core/types/core.py
@@ -147,7 +147,7 @@ class AsyncBaseTransactionsClient(abc.ABC):
     @abc.abstractmethod
     async def create_catalog(
         self, catalog: stac_types.Catalog, catalog_path: Optional[str], **kwargs
-    ) -> Optional[Union[stac_types.Catalog, Response]]:
+    ) -> Optional[stac_types.Catalog | Response]:
         """Create a new catalog.
 
         Called with `POST /catalogs`.
@@ -163,7 +163,7 @@ class AsyncBaseTransactionsClient(abc.ABC):
     @abc.abstractmethod
     async def create_super_catalog(
         self, catalog: stac_types.Catalog, **kwargs
-    ) -> Optional[Union[stac_types.Catalog, Response]]:
+    ) -> Optional[stac_types.Catalog | Response]:
         """Create a new top-level catalog.
 
         Called with `POST /`.
@@ -179,7 +179,7 @@ class AsyncBaseTransactionsClient(abc.ABC):
     @abc.abstractmethod
     async def update_catalog(
         self, catalog_path: str, catalog: stac_types.Catalog, **kwargs
-    ) -> Optional[Union[stac_types.Catalog, Response]]:
+    ) -> Optional[stac_types.Catalog | Response]:
         """Perform a complete update on an existing collection.
 
         Called with `PUT /collections`. It is expected that this item already
@@ -198,7 +198,7 @@ class AsyncBaseTransactionsClient(abc.ABC):
     @abc.abstractmethod
     async def delete_catalog(
         self, catalog_path: str, **kwargs
-    ) -> Optional[Union[stac_types.Catalog, Response]]:
+    ) -> Optional[stac_types.Catalog | Response]:
         """Delete a collection.
 
         Called with `DELETE /collections/{collection_id}`

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/app.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/app.py
@@ -28,6 +28,7 @@ from stac_fastapi.core.session import Session
 from stac_fastapi.elasticsearch.config import ElasticsearchSettings
 from stac_fastapi.elasticsearch.database_logic import (
     DatabaseLogic,
+    create_base_catalog_index,
     create_catalog_index,
     create_collection_index,
     create_index_templates,
@@ -171,6 +172,7 @@ async def _startup_event() -> None:
         await create_index_templates()
         await create_collection_index()
         await create_catalog_index()
+        await create_base_catalog_index()
 
 
 def run() -> None:


### PR DESCRIPTION
## Nested Catalog Support
Updated endpoints and types to allow catalogs to be nested within other catalogs. This includes adding a new `catalog_path` variable to most endpoints to allow more specific identification of catalogs for nesting functionality. Requires updates to transaction extension as well to allow nested catalogs to be created, updated and deleted.
Also updating link functionality to ensure all nested items can be retrieved as expected via the correct URL.