### PR TITLE
Patch/code cleanup for catalogs

### DIFF
--- a/stac_fastapi/core/stac_fastapi/core/base_database_logic.py
+++ b/stac_fastapi/core/stac_fastapi/core/base_database_logic.py
@@ -72,11 +72,6 @@ class BaseDatabaseLogic(abc.ABC):
         pass
 
     @abc.abstractmethod
-    async def create_super_catalog(self, catalog: Dict, refresh: bool = False) -> None:
-        """Create a catalog in the database."""
-        pass
-
-    @abc.abstractmethod
     async def find_catalog(self, catalog_path: str) -> Dict:
         """Find a catalog in the database."""
         pass

--- a/stac_fastapi/core/stac_fastapi/core/core.py
+++ b/stac_fastapi/core/stac_fastapi/core/core.py
@@ -262,7 +262,6 @@ class CoreClient(AsyncBaseCoreClient):
                     limit=limit,
                     token=token,
                     sort=sort,
-                    collection_ids=None,  # search_request.collections,
                     base_url=base_url,
                 )
             )
@@ -1346,35 +1345,6 @@ class TransactionsClient(AsyncBaseTransactionsClient):
             catalog=catalog,
             base_url=base_url,
         )  # not needed here: conformance_classes=self.conformance_classes())
-
-    @overrides
-    async def create_super_catalog(
-        self, catalog: stac_types.Catalog, **kwargs
-    ) -> stac_types.Catalog:
-        """Create a new catalog in the database.
-
-        Args:
-            catalog (stac_types.Catalog): The catalog to be created.
-            kwargs: Additional keyword arguments.
-
-        Returns:
-            stac_types.Catalog: The created catalog object.
-
-        Raises:
-            ConflictError: If the catalog already exists.
-        """
-
-        base_url = str(kwargs["request"].base_url)
-        catalog = CatalogSerializer.stac_to_db(catalog=catalog, base_url=base_url)
-
-        # await self.database.create_super_catalog(catalog=catalog)
-
-        await self.database.create_catalog(catalog=catalog)
-
-        # This catalog does not yet have any collections or sub-catalogs
-        return CatalogSerializer.db_to_stac(
-            catalog_path="base", catalog=catalog, base_url=base_url, sub_catalogs=[]
-        )  # not needed here: conformance_classes=self.conformance_classes()) conformance_classes=self.conformance_classes())
 
     @overrides
     async def update_catalog(

--- a/stac_fastapi/core/stac_fastapi/core/types/core.py
+++ b/stac_fastapi/core/stac_fastapi/core/types/core.py
@@ -161,22 +161,6 @@ class AsyncBaseTransactionsClient(abc.ABC):
         ...
 
     @abc.abstractmethod
-    async def create_super_catalog(
-        self, catalog: stac_types.Catalog, **kwargs
-    ) -> Optional[stac_types.Catalog | Response]:
-        """Create a new top-level catalog.
-
-        Called with `POST /`.
-
-        Args:
-            catalog: the catalog
-
-        Returns:
-            The catalog that was created.
-        """
-        ...
-
-    @abc.abstractmethod
     async def update_catalog(
         self, catalog_path: str, catalog: stac_types.Catalog, **kwargs
     ) -> Optional[stac_types.Catalog | Response]:

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/app.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/app.py
@@ -28,7 +28,6 @@ from stac_fastapi.core.session import Session
 from stac_fastapi.elasticsearch.config import ElasticsearchSettings
 from stac_fastapi.elasticsearch.database_logic import (
     DatabaseLogic,
-    create_base_catalog_index,
     create_catalog_index,
     create_collection_index,
     create_index_templates,
@@ -172,7 +171,6 @@ async def _startup_event() -> None:
         await create_index_templates()
         await create_collection_index()
         await create_catalog_index()
-        await create_base_catalog_index()
 
 
 def run() -> None:

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
@@ -823,9 +823,8 @@ class DatabaseLogic:
         for hit in hits:
             # Construct required catalog indices
             try:
-                catalog_index = hit["_index"].split("_", 1)
                 catalog_id = hit["_id"]
-                catalog_index = catalog_index[1]
+                catalog_index = hit["_index"].split("_", 1)[1]
                 catalog_index_list = catalog_index.split(CATALOG_SEPARATOR)
                 catalog_index_list.reverse()
                 catalog_index_list.append(catalog_id)

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
@@ -822,9 +822,9 @@ class DatabaseLogic:
         catalog_indices_list = []
         for hit in hits:
             # Construct required catalog indices
-            catalog_index = hit["_index"].split("_", 1)
-            catalog_id = hit["_id"]
             try:
+                catalog_index = hit["_index"].split("_", 1)
+                catalog_id = hit["_id"]
                 catalog_index = catalog_index[1]
                 catalog_index_list = catalog_index.split(CATALOG_SEPARATOR)
                 catalog_index_list.reverse()


### PR DESCRIPTION
Minor updates and bugfixes
- Corrected issue with get_all_catalogs than led to index error for top-level catalogs
- Remove unnecessary functions and print statements
- Introduced index separator global variable to improve maintainability