### PR TITLE
Patch/code cleanup for catalogs

### DIFF
--- a/stac_fastapi/core/stac_fastapi/core/core.py
+++ b/stac_fastapi/core/stac_fastapi/core/core.py
@@ -134,6 +134,11 @@ class CoreClient(AsyncBaseCoreClient):
                 {
                     "rel": "data",
                     "type": MimeTypes.json,
+                    "href": urljoin(base_url, "collections"),
+                },
+                {
+                    "rel": "data",
+                    "type": MimeTypes.json,
                     "href": urljoin(base_url, "catalogs"),
                 },
                 {

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
@@ -1570,15 +1570,20 @@ class DatabaseLogic:
 
         es_response = await search_task
 
+        collections = []
         hits = es_response["hits"]["hits"]
-        collections = [
-            self.collection_serializer.db_to_stac(
-                collection=hit["_source"],
-                base_url=base_url,
-                catalog_path=hit["_index"].split("_", 1),
+        for hit in hits:
+            catalog_path = hit["_index"].split("_",1)[1]
+            catalog_path_list = catalog_path.split(CATALOG_SEPARATOR)
+            catalog_path_list.reverse()
+            catalog_path = '/'.join(catalog_path_list)
+            collections.append(
+                self.collection_serializer.db_to_stac(
+                    collection=hit["_source"],
+                    base_url=base_url,
+                    catalog_path=catalog_path,
+                )
             )
-            for hit in hits
-        ]
 
         next_token = None
         if hits and (sort_array := hits[-1].get("sort")):


### PR DESCRIPTION
Bugfix to address following issues:
- Collections endpoint not correctly identified by STAC Browser, now included in top-level `/` response
- Catalog path not correctly determined after collection search