### PR TITLE
Remove collections from landing page to force catalogs instead

### DIFF
--- a/stac_fastapi/core/stac_fastapi/core/core.py
+++ b/stac_fastapi/core/stac_fastapi/core/core.py
@@ -134,11 +134,6 @@ class CoreClient(AsyncBaseCoreClient):
                 {
                     "rel": "data",
                     "type": MimeTypes.json,
-                    "href": urljoin(base_url, "collections"),
-                },
-                {
-                    "rel": "data",
-                    "type": MimeTypes.json,
                     "href": urljoin(base_url, "catalogs"),
                 },
                 {


### PR DESCRIPTION
Bugfix to remove collections from top-level landing page to force catalogs to be displayed instead.
Note, this will result in a collections warning in STAC Browser, as it cannot identify the `/collections` endpoint from the landing page.