### PR TITLE
Correct next link generator to include base url

### DIFF
--- a/stac_fastapi/core/stac_fastapi/core/models/links.py
+++ b/stac_fastapi/core/stac_fastapi/core/models/links.py
@@ -121,7 +121,11 @@ class PagingLinks(BaseLinks):
             # Need to generate next link by combining the current url, including base url, with the next token
             method = self.request.method
             if method == "GET":
-                href = merge_params(self.url, {"token": self.next})
+                parsed_url = urlparse(self.url)
+                netloc = parsed_url.netloc + "/"
+                query_url = self.url.split(netloc)[1]
+                new_url = self.resolve(query_url)
+                href = merge_params(new_url, {"token": self.next})
                 link = dict(
                     rel=Relations.next.value,
                     type=MimeTypes.json.value,


### PR DESCRIPTION
Bugfix to correct next link generator.
Reverted next link logic to ensure the correct base URL is included in the generated URL.