### PR TITLE
Bugfix/collections search query parameters bbox

### DIFF
--- a/stac_fastapi/core/stac_fastapi/core/core.py
+++ b/stac_fastapi/core/stac_fastapi/core/core.py
@@ -228,7 +228,7 @@ class CoreClient(AsyncBaseCoreClient):
         base_url = str(request.base_url)
         limit = int(request.query_params.get("limit", 10))
         token = request.query_params.get("token")
-        
+
         collections, next_token = await self.database.get_all_collections(
             token=token, limit=limit, base_url=base_url
         )
@@ -1636,9 +1636,8 @@ class EsAsyncCollectionSearchClient(AsyncCollectionSearchClient):
             "token": token,
             "bbox": bbox,
             "datetime": datetime,
-            "q": q
+            "q": q,
         }
-        
 
         # Do the request
         try:

--- a/stac_fastapi/core/stac_fastapi/core/core.py
+++ b/stac_fastapi/core/stac_fastapi/core/core.py
@@ -1557,10 +1557,6 @@ class EsAsyncCollectionSearchClient(AsyncCollectionSearchClient):
 
         search = self.database.make_collection_search()
 
-        print(search_request.datetime)
-        print(search_request.bbox)
-        print(search_request.q)
-
         if search_request.datetime:
             datetime_search = CoreClient._return_date(search_request.datetime)
             search = self.database.apply_datetime_collections_filter(

--- a/stac_fastapi/core/stac_fastapi/core/core.py
+++ b/stac_fastapi/core/stac_fastapi/core/core.py
@@ -1610,7 +1610,7 @@ class EsAsyncCollectionSearchClient(AsyncCollectionSearchClient):
         bbox: Optional[List[NumType]] = None,
         datetime: Optional[Union[str, datetime_type]] = None,
         limit: Optional[int] = 10,
-        q: Optional[str] = None,
+        q: Optional[List[str]] = None,
         **kwargs,
     ) -> Collections:
         """Get search results from the database for collections.
@@ -1734,7 +1734,7 @@ class EsAsyncDiscoverySearchClient(AsyncDiscoverySearchClient):
     async def get_discovery_search(
         self,
         request: Request,
-        q: Optional[str] = None,
+        q: Optional[List[str]] = None,
         limit: Optional[int] = 10,
         **kwargs,
     ) -> Collections:

--- a/stac_fastapi/core/stac_fastapi/core/types/core.py
+++ b/stac_fastapi/core/stac_fastapi/core/types/core.py
@@ -13,6 +13,8 @@ from stac_fastapi.types.conformance import BASE_CONFORMANCE_CLASSES
 from stac_fastapi.types.extension import ApiExtension
 from stac_fastapi.types.search import (
     BaseCatalogSearchPostRequest,
+    BaseCollectionSearchPostRequest,
+    BaseDiscoverySearchPostRequest,
     BaseSearchPostRequest,
 )
 from stac_fastapi.types.stac import Conformance
@@ -493,6 +495,16 @@ class AsyncCollectionSearchClient(abc.ABC):
         """
         ...
 
+    async def post_all_collections(
+        self, search_request: BaseCollectionSearchPostRequest, **kwargs
+    ) -> stac_types.Collections:
+        """Get all available collections.
+        Called with `POST /collections`.
+        Returns:
+            A list of collections.
+        """
+        ...
+
 
 @attr.s
 class AsyncDiscoverySearchClient(abc.ABC):
@@ -504,14 +516,29 @@ class AsyncDiscoverySearchClient(abc.ABC):
         limit: Optional[int] = 10,
         **kwargs,
     ) -> stac_types.ItemCollection:
-        """Cross catalog search (GET) for collections.
+        """Cross catalog search (GET) for collections and catalogs.
 
-        Called with `GET /collection-search`.
+        Called with `GET /discovery-search`.
 
         Args:
             search_request: search request parameters.
 
         Returns:
-            A list of collections matching search criteria.
+            A list of collections and catalogs matching search criteria (next pagination token if any).
+        """
+        ...
+
+    async def post_discovery_search(
+        self, search_request: BaseDiscoverySearchPostRequest, **kwargs
+    ) -> stac_types.Collections:
+        """Cross catalog search (POST) for collections and catalogs.
+
+        Called with `POST /discovery-search`.
+
+        Args:
+            search_request: search request parameters.
+
+        Returns:
+            A list of collections and catalogs matching search criteria (next pagination token if any).
         """
         ...

--- a/stac_fastapi/core/stac_fastapi/core/types/core.py
+++ b/stac_fastapi/core/stac_fastapi/core/types/core.py
@@ -473,14 +473,14 @@ class AsyncBaseFiltersClient(abc.ABC):
 class AsyncCollectionSearchClient(abc.ABC):
     """Defines a pattern for implementing the STAC Collection Search extension."""
 
-    async def get_collection_search(
+    async def get_all_collections(
         self,
         bbox: Optional[List[NumType]] = None,
         datetime: Optional[Union[str, datetime]] = None,
         limit: Optional[int] = 10,
         q: Optional[str] = None,
         **kwargs,
-    ) -> stac_types.ItemCollection:
+    ) -> stac_types.Collections:
         """Cross catalog search (GET) for collections.
 
         Called with `GET /collection-search`.

--- a/stac_fastapi/core/stac_fastapi/core/types/core.py
+++ b/stac_fastapi/core/stac_fastapi/core/types/core.py
@@ -478,7 +478,7 @@ class AsyncCollectionSearchClient(abc.ABC):
         bbox: Optional[List[NumType]] = None,
         datetime: Optional[Union[str, datetime]] = None,
         limit: Optional[int] = 10,
-        q: Optional[str] = None,
+        q: Optional[List[str]] = None,
         **kwargs,
     ) -> stac_types.Collections:
         """Cross catalog search (GET) for collections.
@@ -500,7 +500,7 @@ class AsyncDiscoverySearchClient(abc.ABC):
 
     async def get_discovery_search(
         self,
-        q: Optional[str] = None,
+        q: Optional[List[str]] = None,
         limit: Optional[int] = 10,
         **kwargs,
     ) -> stac_types.ItemCollection:

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/app.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/app.py
@@ -6,13 +6,10 @@ from pydantic import BaseModel
 
 from stac_fastapi.api.app import StacApi
 from stac_fastapi.api.models import (
-    EmptyRequest,
     create_get_catalog_request_model,
-    create_get_collections_request_model,
     create_get_request_model,
     create_post_catalog_full_request_model,
     create_post_catalog_request_model,
-    create_post_collections_request_model,
     create_post_request_model,
 )
 from stac_fastapi.core.core import (
@@ -115,12 +112,6 @@ catalog_get_request_model = create_get_catalog_request_model(
     extensions=extensions, base_model=BaseCatalogSearchGetRequest
 )
 
-# TODO: combine into single create_post/get_request_model function
-# could add another parameter here for the model name e.g. "CollectionsGetRequest" to combine
-# these 'create_request_model' functions with those above
-collections_get_request_model = create_get_collections_request_model([], EmptyRequest)
-collections_post_request_model = create_post_collections_request_model([], BaseModel)
-
 # Add discovery search here as it requires all other extensions to be passed to it for conformance classes to be identified
 discovery_search_extension = DiscoverySearchExtension(
     client=EsAsyncDiscoverySearchClient(database=database_logic, extensions=extensions),
@@ -131,16 +122,6 @@ discovery_search_extension.conformance_classes.extend(
 
 extensions.append(discovery_search_extension)
 
-# Check if collection search extension is selected
-for extension in extensions:
-    if isinstance(extension, CollectionSearchExtension):
-        collections_get_request_model = create_get_collections_request_model(
-            [extension], EmptyRequest
-        )
-        collections_post_request_model = create_post_collections_request_model(
-            [extension], BaseModel
-        )
-        break
 
 api = StacApi(
     title=os.getenv("STAC_FASTAPI_TITLE", "stac-fastapi-elasticsearch"),
@@ -156,8 +137,6 @@ api = StacApi(
     ),
     search_get_request_model=get_request_model,
     search_post_request_model=post_request_model,
-    collections_get_request_model=collections_get_request_model,
-    collections_post_request_model=collections_post_request_model,
     search_catalog_get_request_model=catalog_get_request_model,
     search_catalog_post_request_model=catalog_post_full_request_model,
 )

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
@@ -884,6 +884,9 @@ class DatabaseLogic:
         catalogs = []
         for i, hit in enumerate(hits):
             catalog_path = hit["_index"].split("_", 1)[1]
+            catalog_path_list = catalog_path.split(CATALOG_SEPARATOR)
+            catalog_path_list.reverse()
+            catalog_path = "/".join(catalog_path_list)
             sub_data_catalogs_and_collections = child_data[i]
             # Extract sub-catalogs
             sub_catalogs = []

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
@@ -883,6 +883,7 @@ class DatabaseLogic:
 
         catalogs = []
         for i, hit in enumerate(hits):
+            catalog_path = hit["_index"].split("_", 1)[1]
             sub_data_catalogs_and_collections = child_data[i]
             # Extract sub-catalogs
             sub_catalogs = []
@@ -1240,8 +1241,8 @@ class DatabaseLogic:
         return search.query(Q("bool", filter=[Q("bool", must=must)]))
 
     @staticmethod
-    def apply_keyword_collections_filter(search: Search, q: str):
-        keyword_list = [keyword.strip() for keyword in q.split(",")]
+    def apply_keyword_collections_filter(search: Search, q: List[str]):
+        q_str = ",".join(q)
         should = []
         should.extend(
             [
@@ -1250,7 +1251,7 @@ class DatabaseLogic:
                     filter=[
                         Q(
                             "match",
-                            title={"query": q},
+                            title={"query": q_str},
                         ),
                     ],
                 ),
@@ -1259,14 +1260,14 @@ class DatabaseLogic:
                     filter=[
                         Q(
                             "match",
-                            description={"query": q},
+                            description={"query": q_str},
                         ),
                     ],
                 ),
                 Q(
                     "bool",
                     filter=[
-                        Q("terms", keywords=keyword_list),
+                        Q("terms", keywords=q),
                     ],
                 ),
             ]
@@ -1277,8 +1278,8 @@ class DatabaseLogic:
         return search
 
     @staticmethod
-    def apply_keyword_discovery_filter(search: Search, q: str):
-        keyword_list = [keyword.strip() for keyword in q.split(",")]
+    def apply_keyword_discovery_filter(search: Search, q: List[str]):
+        q_str = ",".join(q)
         # Construct search query for keywords
         # For catalogues and collections this searches title and description
         # For collections this also searches keywords
@@ -1288,32 +1289,32 @@ class DatabaseLogic:
                 Q(
                     "bool",
                     filter=[
-                        Q("match", title=q),
+                        Q("match", title=q_str),
                     ],
                 ),
                 Q(
                     "bool",
                     filter=[
-                        Q("match", description=q),
+                        Q("match", description=q_str),
                     ],
                 ),
                 Q(
                     "bool",
                     filter=[
-                        Q("terms", keywords=keyword_list),
+                        Q("terms", keywords=q),
                     ],
                 ),
             ]
         )
         # The following query is then used to score the returned results
         # Calculate scoring for keyword field
-        should_query = [{"term": {"keywords": keyword}} for keyword in keyword_list]
+        should_query = [{"term": {"keywords": keyword}} for keyword in q]
         # Calculate scoring for title and description fields
         should_query.extend(
             [
                 {
                     "multi_match": {
-                        "query": q,
+                        "query": q_str,
                         "fields": ["title", "description"],
                         "type": "most_fields",
                     }
@@ -1573,10 +1574,10 @@ class DatabaseLogic:
         collections = []
         hits = es_response["hits"]["hits"]
         for hit in hits:
-            catalog_path = hit["_index"].split("_",1)[1]
+            catalog_path = hit["_index"].split("_", 1)[1]
             catalog_path_list = catalog_path.split(CATALOG_SEPARATOR)
             catalog_path_list.reverse()
-            catalog_path = '/'.join(catalog_path_list)
+            catalog_path = "/".join(catalog_path_list)
             collections.append(
                 self.collection_serializer.db_to_stac(
                     collection=hit["_source"],
@@ -2772,9 +2773,12 @@ class DatabaseLogic:
         hits = es_response["hits"]["hits"]
 
         data = []
+        catalog_hits = []
+        collection_hits = []
         catalog_index_lists_for_catalogs = []
         for hit in hits:
             if hit["_source"]["type"] == "Catalog":
+                catalog_hits.append(hit)
                 # Calculate catalog path for found catalog
                 catalog_index = hit["_index"].split("_", 1)[1]
                 catalog_id = hit["_id"]
@@ -2783,6 +2787,8 @@ class DatabaseLogic:
                 catalog_index_list.append(catalog_id)
                 catalog_index_lists_for_catalogs.append(catalog_index_list)
                 catalog_index = "/".join(catalog_index_list)
+            else:
+                collection_hits.append(hit)
 
         catalogs_results = await asyncio.gather(
             *[
@@ -2804,7 +2810,7 @@ class DatabaseLogic:
             (
                 result
                 if not isinstance(result, Exception)
-                else {"hits": {"hits": [{"_source": []}]}}
+                else {"hits": {"hits": [{"_source": {}}]}}
             )
             for result in catalogs_results
         ]
@@ -2834,7 +2840,7 @@ class DatabaseLogic:
             (
                 result
                 if not isinstance(result, Exception)
-                else {"hits": {"hits": [{"_source": []}]}}
+                else {"hits": {"hits": [{"_source": {}}]}}
             )
             for result in collections_results
         ]
@@ -2845,7 +2851,7 @@ class DatabaseLogic:
 
         child_data = list(zip(sub_catalogs_responses, collection_responses))
 
-        for i, hit in enumerate(hits):
+        for i, hit in enumerate(catalog_hits):
             if hit["_source"]["type"] == "Catalog":
                 catalog_index_list = (
                     hit["_index"].split("_", 1)[1].split(CATALOG_SEPARATOR)
@@ -2853,6 +2859,7 @@ class DatabaseLogic:
                 catalog_index_list.reverse()
                 catalog_index = "/".join(catalog_index_list)
                 sub_data_catalogs_and_collections = child_data[i]
+
                 # Extract sub-catalogs
                 sub_catalogs = []
                 for catalog in sub_data_catalogs_and_collections[0]:
@@ -2861,26 +2868,38 @@ class DatabaseLogic:
                 collections = []
                 for collection in sub_data_catalogs_and_collections[1]:
                     collections.append(collection["_source"])
-            elif hit["_source"]["type"] == "Collection":
+                data.append(
+                    self.catalog_collection_serializer.db_to_stac(
+                        collection_serializer=self.collection_serializer,
+                        catalog_serializer=self.catalog_serializer,
+                        data=hit["_source"],
+                        base_url=base_url,
+                        catalog_path=catalog_index,
+                        sub_catalogs=sub_catalogs,
+                        collections=collections,
+                        conformance_classes=conformance_classes,
+                    )
+                )
+        for i, hit in enumerate(collection_hits):
+            if hit["_source"]["type"] == "Collection":
                 catalog_index = hit["_index"].split("_", 1)[1]
                 catalog_index_list = catalog_index.split(CATALOG_SEPARATOR)
                 catalog_index_list.reverse()
                 catalog_index = "/".join(catalog_index_list)
                 sub_catalogs = []
                 collections = []
-
-            data.append(
-                self.catalog_collection_serializer.db_to_stac(
-                    collection_serializer=self.collection_serializer,
-                    catalog_serializer=self.catalog_serializer,
-                    data=hit["_source"],
-                    base_url=base_url,
-                    catalog_path=catalog_index,
-                    sub_catalogs=sub_catalogs,
-                    collections=collections,
-                    conformance_classes=conformance_classes,
+                data.append(
+                    self.catalog_collection_serializer.db_to_stac(
+                        collection_serializer=self.collection_serializer,
+                        catalog_serializer=self.catalog_serializer,
+                        data=hit["_source"],
+                        base_url=base_url,
+                        catalog_path=catalog_index,
+                        sub_catalogs=sub_catalogs,
+                        collections=collections,
+                        conformance_classes=conformance_classes,
+                    )
                 )
-            )
 
         next_token = None
         if hits and (sort_array := hits[-1].get("sort")):


### PR DESCRIPTION
Bugfix to correct issue with interpretation of collection-search BBOX input.
Also updated code elsewhere to:
- Remove unnecessary parameter from collection-search call
- Split up collection-search extension code from core `/collections` implementation. Includes removing unnecessary default classes
- Define abstract methods for collection and discovery search extensions, to better align with core implementation
- Improve discovery-search implementation to ensure all nested catalogs and collections are returned for catalog results.
- Corrected links in response from `/catalogs` endpoint (app-dev issue)