### PR TITLE
Feature/eodhp 325 add check for catalog existence before creation

### DIFF
--- a/stac_fastapi/core/stac_fastapi/core/core.py
+++ b/stac_fastapi/core/stac_fastapi/core/core.py
@@ -1299,6 +1299,9 @@ class TransactionsClient(AsyncBaseTransactionsClient):
         catalog = self.database.catalog_serializer.stac_to_db(
             catalog=catalog, base_url=base_url
         )
+        catalog = await self.database.prep_create_catalog(
+            catalog_path=catalog_path, catalog=catalog, base_url=base_url
+        )
 
         await self.database.create_catalog(catalog_path=catalog_path, catalog=catalog)
 


### PR DESCRIPTION
## Updating Catalog Creation Functionality to Improve Reliability
- Ensure parent catalog exists before ingesting new sub-catalog
- Introduce new functions (async and sync) for catalog creation, `prep_create_catalog` to confirm existence. Aligns with core collection functionality.
- This is useful for ingesting ADES outputs, as it ensure `user-datasets` exists in the database before ingesting outputs.

Also, general code clean up, including:
- Comments for catalog path variables
- Correcting response code for incorrect query parameters when searching