### PR TITLE
Feature/eodhp 481 access control for resource catalogue entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,72 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## EODHP
+The following changes have been made for the EODHP project
+### v0.3.7 - 2024-07-02
+Catalog creation logic improvement
+- Ensure parent catalog exists before creating child
+- Two new functions implemented (async and sync) for catalog preparation
+
+Code clean up
+  - Comments for nested catalog logic
+  - Correct response code for incorrect query parameters when searching
+  - Split up collection-search extension from core `/collections` implementation
+  - Defining abstract functions for collection and discovery search extensions  
+
+Bugfixes
+  - Remove unnecessary parameter from collection-search call
+  - Improve discovery-search implementation to ensure all nested catalogs and collections are returned in catalog responses
+  - Corrected links in response form `/catalogs` endpoints
+### v0.3.6 - 2024-06-14
+## Support nested catalogs
+- Data within (arbitrarily) nested catalogs can be accessed as before with the provided catalog path parameter, e.g. `/supported-datasets/dataset-1`
+- Requires `catalog_path` parameter to be provided to specify where in the catalog directories the data should be placed/recalled from
+- Update endpoints to support nested catalog definition in URL path
+- Better support for STAC-Browser and pystac python client:
+  - Updating link generator logic
+### v0.3.5 - 2024-05-31
+Support configuration for read-only deployments:
+- Allow transaction extensions (including Bulk Transactions) to be disabled by environment variable (STAC_FASTAPI_ENABLE_TRANSACTIONS) at deployment time
+- STAC-fastapi instances can be defined as either read-only (transaction endpoints disabled) or read-write (with all transactions endpoints enabled)
+
+The following bugs were also addressed:
+- Corrected update catalog functionality to reindex all items sitting within the updated catalog when the catalog id is changed
+- Corrected issue with pagination links being broken and added support for discovery and collections search
+### v0.3.4 - 2024-05-14
+#### Added new endpoint to allow free-text searching of collections and catalogues:
+- New endpoints:
+  - Discovery Search (GET/POST)
+  - This queries title, description and keyword (collections only) fields when available
+#### Added support for catalogues to split up collections and items into catalogues of data
+  - This leads to updates for the following endpoints to filter by catalogues:
+    - Get Collection
+    - Get ItemCollection
+    - Get CatalogCollections
+    - Create Item
+    - Update Item
+    - Delete Item
+    - Create Collection
+    - Update Collection
+    - Delete Collection
+  - New endpoints added for catalogues:
+    - Update Catalog
+    - Create Catalog
+    - Delete Catalog
+    - Get Catalogs
+##### Minor changes
+- Update to the datetime handling for Get ItemCollection to include string converter.
+### v0.3.3 - 2024-05-08
+Including fix to address incorrect links returned from `/search` and `/collection-search` endpoints defining the `self` and `next` item locations.
+### v0.3.2 - 2024-05-01
+Bugfixes:
+- Bugfix for missing collection search links
+- Bugfix to address JSON validation error in search results
+### V0.3.1 - 2024-04-26
+General code clean up to improve initialisation commands
+### V3.0.0 - 2024-04-23
+Added [collection search](https://github.com/stac-api-extensions/collection-search) to STAC Fastapi  allowing spatial and temporal searching of collections by BBOX and datetime.
+
 ## [Unreleased]
 
 ## [v2.2.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## EODHP
 The following changes have been made for the EODHP project
+### V0.3.8 - 2024-07-30
+Access-Control Logic in Catalog
+- Adding access control to catalogs and collections added to the catalogue
+- Access limited based on incoming `authorization` header username
+- Workspace parameter used when creating/editing entries to ensure workspace has required access to make the requested changes
+- Access determined by hashing the provided username or workspace name, storing in elasticsearch and filtering results
 ### v0.3.7 - 2024-07-02
 Catalog creation logic improvement
 - Ensure parent catalog exists before creating child

--- a/stac_fastapi/core/stac_fastapi/core/access_control.py
+++ b/stac_fastapi/core/stac_fastapi/core/access_control.py
@@ -39,11 +39,13 @@ def create_bitstring(uid, gids=[], is_public=False):
     bitstring = ''.join(str(bit) for bit in bitstring)
     return bitstring
 
+# Not used
 def add_user(bitstring, new_user):
     index = hash_to_index(new_user, len(bitstring))
     set_bit(bitstring, index)
     return bitstring
 
+# Not used
 def remove_user(bitstring, user):
     index = hash_to_index(user, len(bitstring))
     set_bit(bitstring, index, allow=False)

--- a/stac_fastapi/core/stac_fastapi/core/access_control.py
+++ b/stac_fastapi/core/stac_fastapi/core/access_control.py
@@ -1,0 +1,50 @@
+import hashlib
+import os
+
+# Set the size of the hash table
+NUMBER_OF_USERS = os.getenv("NUMBER_OF_USERS", 1024)  # Default to 1024 users
+
+def hash_to_index(value, bitstring_size=NUMBER_OF_USERS): # 1023 in binary is 1111111111
+    if not value:
+        # If no user provided, return public index
+        return NUMBER_OF_USERS - 1
+    # Compute SHA-256 hash and take the last X bits for the index
+    hash_object = hashlib.sha256(value.encode())
+    hash_digest = hash_object.digest()
+    hash_int = int.from_bytes(hash_digest, byteorder='big')
+    index = hash_int & (bitstring_size - 2)  # Exclude the fully-public bit
+    return index
+
+
+def set_bit(bitstring, index, allow=True):
+    if allow:
+        bitstring[index] = 1
+    else:
+        bitstring[index] = 0
+
+def create_bitstring(uid, gids=[], is_public=False):
+    bitstring_size = NUMBER_OF_USERS
+    bitstring = [0] * bitstring_size
+    # Handle user access bit
+    if uid:
+        index = hash_to_index(uid)
+        set_bit(bitstring, index)
+    # Handle group access bits
+    for gid in gids:
+        index = hash_to_index(gid)
+        set_bit(bitstring, index)
+    # Set the fully-public bit
+    if is_public:
+        bitstring[-1] = 1
+    bitstring = ''.join(str(bit) for bit in bitstring)
+    return bitstring
+
+def add_user(bitstring, new_user):
+    index = hash_to_index(new_user, len(bitstring))
+    set_bit(bitstring, index)
+    return bitstring
+
+def remove_user(bitstring, user):
+    index = hash_to_index(user, len(bitstring))
+    set_bit(bitstring, index, allow=False)
+    return bitstring

--- a/stac_fastapi/core/stac_fastapi/core/access_control.py
+++ b/stac_fastapi/core/stac_fastapi/core/access_control.py
@@ -4,14 +4,17 @@ import os
 # Set the size of the hash table
 NUMBER_OF_USERS = os.getenv("NUMBER_OF_USERS", 1024)  # Default to 1024 users
 
-def hash_to_index(value, bitstring_size=NUMBER_OF_USERS): # 1023 in binary is 1111111111
+
+def hash_to_index(
+    value, bitstring_size=NUMBER_OF_USERS
+):  # 1023 in binary is 1111111111
     if not value:
         # If no user provided, return public index
         return NUMBER_OF_USERS - 1
     # Compute SHA-256 hash and take the last X bits for the index
     hash_object = hashlib.sha256(value.encode())
     hash_digest = hash_object.digest()
-    hash_int = int.from_bytes(hash_digest, byteorder='big')
+    hash_int = int.from_bytes(hash_digest, byteorder="big")
     index = hash_int & (bitstring_size - 2)  # Exclude the fully-public bit
     return index
 
@@ -21,6 +24,7 @@ def set_bit(bitstring, index, allow=True):
         bitstring[index] = 1
     else:
         bitstring[index] = 0
+
 
 def create_bitstring(uid, gids=[], is_public=False):
     bitstring_size = NUMBER_OF_USERS
@@ -36,14 +40,16 @@ def create_bitstring(uid, gids=[], is_public=False):
     # Set the fully-public bit
     if is_public:
         bitstring[-1] = 1
-    bitstring = ''.join(str(bit) for bit in bitstring)
+    bitstring = "".join(str(bit) for bit in bitstring)
     return bitstring
+
 
 # Not used
 def add_user(bitstring, new_user):
     index = hash_to_index(new_user, len(bitstring))
     set_bit(bitstring, index)
     return bitstring
+
 
 # Not used
 def remove_user(bitstring, user):

--- a/stac_fastapi/core/stac_fastapi/core/base_database_logic.py
+++ b/stac_fastapi/core/stac_fastapi/core/base_database_logic.py
@@ -1,7 +1,7 @@
 """Base database logic."""
 
 import abc
-from typing import Any, Dict, Iterable, Optional, List
+from typing import Any, Dict, Iterable, List, Optional
 
 
 class BaseDatabaseLogic(abc.ABC):
@@ -47,7 +47,13 @@ class BaseDatabaseLogic(abc.ABC):
 
     @abc.abstractmethod
     async def create_collection(
-        self, catalog_path: str, collection: Dict, username_header: dict, workspace: str, is_public: bool, refresh: bool = False
+        self,
+        catalog_path: str,
+        collection: Dict,
+        username_header: dict,
+        workspace: str,
+        is_public: bool,
+        refresh: bool = False,
     ) -> None:
         """Create a collection in the database."""
         pass
@@ -66,7 +72,11 @@ class BaseDatabaseLogic(abc.ABC):
 
     @abc.abstractmethod
     async def create_catalog(
-        self, catalog: Dict, access_control: List[int], catalog_path: Optional[str], refresh: bool = False
+        self,
+        catalog: Dict,
+        access_control: List[int],
+        catalog_path: Optional[str],
+        refresh: bool = False,
     ) -> None:
         """Create a catalog in the database."""
         pass

--- a/stac_fastapi/core/stac_fastapi/core/base_database_logic.py
+++ b/stac_fastapi/core/stac_fastapi/core/base_database_logic.py
@@ -1,7 +1,7 @@
 """Base database logic."""
 
 import abc
-from typing import Any, Dict, Iterable, Optional
+from typing import Any, Dict, Iterable, Optional, List
 
 
 class BaseDatabaseLogic(abc.ABC):
@@ -47,7 +47,7 @@ class BaseDatabaseLogic(abc.ABC):
 
     @abc.abstractmethod
     async def create_collection(
-        self, catalog_path: str, collection: Dict, refresh: bool = False
+        self, catalog_path: str, collection: Dict, username_header: dict, workspace: str, is_public: bool, refresh: bool = False
     ) -> None:
         """Create a collection in the database."""
         pass
@@ -66,7 +66,7 @@ class BaseDatabaseLogic(abc.ABC):
 
     @abc.abstractmethod
     async def create_catalog(
-        self, catalog: Dict, catalog_path: Optional[str], refresh: bool = False
+        self, catalog: Dict, access_control: List[int], catalog_path: Optional[str], refresh: bool = False
     ) -> None:
         """Create a catalog in the database."""
         pass

--- a/stac_fastapi/core/stac_fastapi/core/core.py
+++ b/stac_fastapi/core/stac_fastapi/core/core.py
@@ -20,13 +20,7 @@ from stac_pydantic.links import Relations
 from stac_pydantic.shared import MimeTypes
 from stac_pydantic.version import STAC_VERSION
 
-from stac_fastapi.core.access_control import (
-    add_user,
-    create_bitstring,
-    hash_to_index,
-    remove_user,
-    set_bit,
-)
+from stac_fastapi.core.access_control import create_bitstring, hash_to_index
 from stac_fastapi.core.base_database_logic import BaseDatabaseLogic
 from stac_fastapi.core.base_settings import ApiBaseSettings
 from stac_fastapi.core.models.links import PagingLinks
@@ -2334,7 +2328,7 @@ class EsAsyncDiscoverySearchClient(AsyncDiscoverySearchClient):
         for data in catalogs_and_collections[:]:
             # Get access control array for this collection
             access_control = data["access_control"]
-            tet = data.pop("access_control")
+            data.pop("access_control")
             # Remove collection from list if user does not have access
             if not int(access_control[-1]) and not int(access_control[user_index]):
                 catalogs_and_collections.remove(data)

--- a/stac_fastapi/core/stac_fastapi/core/core.py
+++ b/stac_fastapi/core/stac_fastapi/core/core.py
@@ -1883,8 +1883,15 @@ class TransactionsClient(AsyncBaseTransactionsClient):
         # e.g. user-datasets/user-workspace/collection
         if workspace != "default_workspace":
             catalog_path_with_slash = f"{catalog_path}/" if catalog_path else ""
-            # This workspace can only write to the user-datasets/user-workspace sub-catalog
-            if not catalog_path or not catalog_path_with_slash.startswith(
+            # This workspace can create its own subcatalog with the same id as the workspace name
+            if (
+                catalog_path
+                and catalog_path.startswith("user-datasets")
+                and catalog["id"] == workspace
+            ):
+                username = workspace
+            # This workspace can then only write to the user-datasets/user-workspace sub-catalog
+            elif not catalog_path or not catalog_path_with_slash.startswith(
                 f"user-datasets/{workspace}/"
             ):
                 raise HTTPException(

--- a/stac_fastapi/core/stac_fastapi/core/core.py
+++ b/stac_fastapi/core/stac_fastapi/core/core.py
@@ -273,11 +273,15 @@ class CoreClient(AsyncBaseCoreClient):
         collections = []
 
         while True:
-            temp_collections, next_token, hit_tokens = await self.database.get_all_collections(
-                token=token, limit=limit, base_url=base_url
+            temp_collections, next_token, hit_tokens = (
+                await self.database.get_all_collections(
+                    token=token, limit=limit, base_url=base_url
+                )
             )
 
-            for i, (collection, hit_token) in enumerate(zip(temp_collections, hit_tokens)):
+            for i, (collection, hit_token) in enumerate(
+                zip(temp_collections, hit_tokens)
+            ):
                 # Get access control array for each collection
                 access_control = collection["access_control"]
                 collection.pop("access_control")
@@ -341,13 +345,15 @@ class CoreClient(AsyncBaseCoreClient):
 
         while True:
             # Search is run continually until limit is reached or no more results
-            temp_catalogs, next_token, hit_tokens = await self.database.get_all_catalogs(
-                catalog_path=catalog_path,
-                token=token,
-                limit=limit,
-                base_url=base_url,
-                user_index=user_index,
-                conformance_classes=self.conformance_classes(),
+            temp_catalogs, next_token, hit_tokens = (
+                await self.database.get_all_catalogs(
+                    catalog_path=catalog_path,
+                    token=token,
+                    limit=limit,
+                    base_url=base_url,
+                    user_index=user_index,
+                    conformance_classes=self.conformance_classes(),
+                )
             )
 
             for i, (catalog, hit_token) in enumerate(zip(temp_catalogs, hit_tokens)):
@@ -470,7 +476,7 @@ class CoreClient(AsyncBaseCoreClient):
             )
 
         # Assume at most 100 collections in a catalog for the time being, may need to increase
-        collections, _, _= await self.database.get_catalog_collections(
+        collections, _, _ = await self.database.get_catalog_collections(
             catalog_path=catalog_path,
             base_url=base_url,
             limit=NUMBER_OF_CATALOG_COLLECTIONS,
@@ -565,15 +571,19 @@ class CoreClient(AsyncBaseCoreClient):
         collections = []
 
         while True:
-            temp_collections, next_token, hit_tokens = await self.database.get_catalog_collections(
-                catalog_path=catalog_path,
-                token=token,  # type: ignore
-                limit=limit,
-                base_url=base_url,
+            temp_collections, next_token, hit_tokens = (
+                await self.database.get_catalog_collections(
+                    catalog_path=catalog_path,
+                    token=token,  # type: ignore
+                    limit=limit,
+                    base_url=base_url,
+                )
             )
 
             # Check if current user has access to each collection
-            for i, (collection, hit_token) in enumerate(zip(temp_collections, hit_tokens)):
+            for i, (collection, hit_token) in enumerate(
+                zip(temp_collections, hit_tokens)
+            ):
                 # Get access control array for each collection
                 access_control = collection["access_control"]
                 collection.pop("access_control")
@@ -1054,13 +1064,15 @@ class CoreClient(AsyncBaseCoreClient):
         items = []
 
         while True:
-            temp_items, maybe_count, next_token, hit_tokens = await self.database.execute_search(
-                search=search,
-                limit=limit,
-                token=token,  # type: ignore
-                sort=sort,
-                collection_ids=search_request.collections,
-                catalog_paths=search_request.catalog_paths,
+            temp_items, maybe_count, next_token, hit_tokens = (
+                await self.database.execute_search(
+                    search=search,
+                    limit=limit,
+                    token=token,  # type: ignore
+                    sort=sort,
+                    collection_ids=search_request.collections,
+                    catalog_paths=search_request.catalog_paths,
+                )
             )
 
             # Filter results to those that are accessible to the user
@@ -1106,7 +1118,6 @@ class CoreClient(AsyncBaseCoreClient):
                 # TODO: implement smarter token logic to return token of last returned ES entry
                 break
             token = next_token
-
 
         # To handle catalog_id in links execute_search also returns the catalog_id
         # from search results in a tuple
@@ -1391,13 +1402,15 @@ class CoreClient(AsyncBaseCoreClient):
         items = []
 
         while True:
-            temp_items, maybe_count, next_token, hit_tokens = await self.database.execute_search(
-                search=search,
-                limit=limit,
-                token=token,  # type: ignore
-                sort=sort,
-                collection_ids=collections,
-                catalog_paths=[catalog_path],
+            temp_items, maybe_count, next_token, hit_tokens = (
+                await self.database.execute_search(
+                    search=search,
+                    limit=limit,
+                    token=token,  # type: ignore
+                    sort=sort,
+                    collection_ids=collections,
+                    catalog_paths=[catalog_path],
+                )
             )
 
             # Filter results to those that are accessible to the user
@@ -2290,7 +2303,9 @@ class EsAsyncCollectionSearchClient(AsyncCollectionSearchClient):
             )
 
             # Filter results to those that are accessible to the user
-            for i, (collection, hit_token) in enumerate(zip(temp_collections, hit_tokens)):
+            for i, (collection, hit_token) in enumerate(
+                zip(temp_collections, hit_tokens)
+            ):
                 # Get access control array for this collection
                 access_control = collection["access_control"]
                 collection.pop("access_control")
@@ -2452,7 +2467,9 @@ class EsAsyncDiscoverySearchClient(AsyncDiscoverySearchClient):
             )
 
             # Filter results to those that are accessible to the user
-            for i, (data, hit_token) in enumerate(zip(temp_catalogs_and_collections, hit_tokens)):
+            for i, (data, hit_token) in enumerate(
+                zip(temp_catalogs_and_collections, hit_tokens)
+            ):
                 # Get access control array for this collection
                 access_control = data["access_control"]
                 data.pop("access_control")

--- a/stac_fastapi/core/stac_fastapi/core/core.py
+++ b/stac_fastapi/core/stac_fastapi/core/core.py
@@ -357,13 +357,8 @@ class CoreClient(AsyncBaseCoreClient):
                 # Add catalog to list if user has access
                 if int(access_control[-1]) or int(access_control[user_index]):
                     catalogs.append(catalog)
-                    print("catalogs length is ", len(catalogs))
-                    print("limit is ", limit)
                     if len(catalogs) >= limit:
-                        print("here")
-                        print(i)
                         if i < len(temp_catalogs) - 1:
-                            print("AND FINALLY HERE")
                             # Extract token from last result
                             next_token = hit_token
                             break
@@ -1283,7 +1278,6 @@ class CoreClient(AsyncBaseCoreClient):
         username_header: dict,
         **kwargs,
     ) -> ItemCollection:
-        print("post search")
         """
         Perform a POST search on a specific sub-catalog.
 

--- a/stac_fastapi/core/stac_fastapi/core/serializers.py
+++ b/stac_fastapi/core/stac_fastapi/core/serializers.py
@@ -270,7 +270,7 @@ class CatalogSerializer(Serializer):
         for link in catalog_links:
             link_rels.append(link["rel"])
             if link["rel"] == "conformance":
-                link["href"] = urljoin(base_url, f"conformance")
+                link["href"] = urljoin(base_url, "conformance")
             elif link["rel"] == "root":
                 link["href"] = urljoin(base_url, f"{catalog_url}")
             elif link["rel"] == "self":
@@ -304,7 +304,7 @@ class CatalogSerializer(Serializer):
                 {
                     "rel": Relations.conformance.value,
                     "type": MimeTypes.json,
-                    "href": urljoin(base_url, f"conformance"),
+                    "href": urljoin(base_url, "conformance"),
                 }
             )
         if "root" not in link_rels:

--- a/stac_fastapi/core/stac_fastapi/core/types/core.py
+++ b/stac_fastapi/core/stac_fastapi/core/types/core.py
@@ -78,7 +78,12 @@ class AsyncBaseTransactionsClient(abc.ABC):
 
     @abc.abstractmethod
     async def delete_item(
-        self, item_id: str, collection_id: str, catalog_path: str, workspace: str, **kwargs
+        self,
+        item_id: str,
+        collection_id: str,
+        catalog_path: str,
+        workspace: str,
+        **kwargs,
     ) -> Optional[Union[stac_types.Item, Response]]:
         """Delete an item from a collection.
 
@@ -95,7 +100,12 @@ class AsyncBaseTransactionsClient(abc.ABC):
 
     @abc.abstractmethod
     async def create_collection(
-        self, catalog_path: str, collection: stac_types.Collection, workspace: str, is_public: bool = False, **kwargs
+        self,
+        catalog_path: str,
+        collection: stac_types.Collection,
+        workspace: str,
+        is_public: bool = False,
+        **kwargs,
     ) -> Optional[Union[stac_types.Collection, Response]]:
         """Create a new collection.
 
@@ -151,7 +161,12 @@ class AsyncBaseTransactionsClient(abc.ABC):
 
     @abc.abstractmethod
     async def create_catalog(
-        self, catalog: stac_types.Catalog, workspace: str, catalog_path: Optional[str], is_public: bool = False, **kwargs
+        self,
+        catalog: stac_types.Catalog,
+        workspace: str,
+        catalog_path: Optional[str],
+        is_public: bool = False,
+        **kwargs,
     ) -> Optional[stac_types.Catalog | Response]:
         """Create a new catalog.
 

--- a/stac_fastapi/core/stac_fastapi/core/types/core.py
+++ b/stac_fastapi/core/stac_fastapi/core/types/core.py
@@ -35,6 +35,7 @@ class AsyncBaseTransactionsClient(abc.ABC):
         catalog_path: str,
         collection_id: str,
         item: Union[stac_types.Item, stac_types.ItemCollection],
+        workspace: str,
         **kwargs,
     ) -> Optional[Union[stac_types.Item, Response, None]]:
         """Create a new item.
@@ -57,6 +58,7 @@ class AsyncBaseTransactionsClient(abc.ABC):
         collection_id: str,
         item_id: str,
         item: stac_types.Item,
+        workspace: str,
         **kwargs,
     ) -> Optional[Union[stac_types.Item, Response]]:
         """Perform a complete update on an existing item.
@@ -76,7 +78,7 @@ class AsyncBaseTransactionsClient(abc.ABC):
 
     @abc.abstractmethod
     async def delete_item(
-        self, item_id: str, collection_id: str, catalog_path: str, **kwargs
+        self, item_id: str, collection_id: str, catalog_path: str, workspace: str, **kwargs
     ) -> Optional[Union[stac_types.Item, Response]]:
         """Delete an item from a collection.
 
@@ -93,7 +95,7 @@ class AsyncBaseTransactionsClient(abc.ABC):
 
     @abc.abstractmethod
     async def create_collection(
-        self, catalog_path: str, collection: stac_types.Collection, **kwargs
+        self, catalog_path: str, collection: stac_types.Collection, workspace: str, is_public: bool = False, **kwargs
     ) -> Optional[Union[stac_types.Collection, Response]]:
         """Create a new collection.
 
@@ -113,6 +115,7 @@ class AsyncBaseTransactionsClient(abc.ABC):
         catalog_path: str,
         collection_id: str,
         collection: stac_types.Collection,
+        workspace: str,
         **kwargs,
     ) -> Optional[Union[stac_types.Collection, Response]]:
         """Perform a complete update on an existing collection.
@@ -132,7 +135,7 @@ class AsyncBaseTransactionsClient(abc.ABC):
 
     @abc.abstractmethod
     async def delete_collection(
-        self, catalog_path: str, collection_id: str, **kwargs
+        self, catalog_path: str, collection_id: str, workspace: str, **kwargs
     ) -> Optional[Union[stac_types.Collection, Response]]:
         """Delete a collection.
 
@@ -148,7 +151,7 @@ class AsyncBaseTransactionsClient(abc.ABC):
 
     @abc.abstractmethod
     async def create_catalog(
-        self, catalog: stac_types.Catalog, catalog_path: Optional[str], **kwargs
+        self, catalog: stac_types.Catalog, workspace: str, catalog_path: Optional[str], is_public: bool = False, **kwargs
     ) -> Optional[stac_types.Catalog | Response]:
         """Create a new catalog.
 
@@ -164,7 +167,7 @@ class AsyncBaseTransactionsClient(abc.ABC):
 
     @abc.abstractmethod
     async def update_catalog(
-        self, catalog_path: str, catalog: stac_types.Catalog, **kwargs
+        self, catalog_path: str, catalog: stac_types.Catalog, workspace: str, **kwargs
     ) -> Optional[stac_types.Catalog | Response]:
         """Perform a complete update on an existing collection.
 
@@ -183,7 +186,7 @@ class AsyncBaseTransactionsClient(abc.ABC):
 
     @abc.abstractmethod
     async def delete_catalog(
-        self, catalog_path: str, **kwargs
+        self, catalog_path: str, workspace: str, **kwargs
     ) -> Optional[stac_types.Catalog | Response]:
         """Delete a collection.
 

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/app.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/app.py
@@ -2,8 +2,6 @@
 
 import os
 
-from pydantic import BaseModel
-
 from stac_fastapi.api.app import StacApi
 from stac_fastapi.api.models import (
     create_get_catalog_request_model,

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
@@ -711,8 +711,8 @@ class DatabaseLogic:
                 )
             )
             if hit.get("sort"):
-                    hit_token = hit["sort"][0]
-                    hit_tokens.append(hit_token)
+                hit_token = hit["sort"][0]
+                hit_tokens.append(hit_token)
             else:
                 hit_tokens.append(None)
 
@@ -950,8 +950,8 @@ class DatabaseLogic:
                 )
             )
             if hit.get("sort"):
-                    hit_token = hit["sort"][0]
-                    hit_tokens.append(hit_token)
+                hit_token = hit["sort"][0]
+                hit_tokens.append(hit_token)
             else:
                 hit_tokens.append(None)
 
@@ -3185,9 +3185,7 @@ class DatabaseLogic:
 
         hit_tokens = []
         for i, hit in enumerate(catalog_hits):
-            catalog_index_list = (
-                hit["_index"].split("_", 1)[1].split(CATALOG_SEPARATOR)
-            )
+            catalog_index_list = hit["_index"].split("_", 1)[1].split(CATALOG_SEPARATOR)
             catalog_index_list.reverse()
             catalog_index = "/".join(catalog_index_list)
             sub_data_catalogs_and_collections = child_data[i]

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
@@ -718,8 +718,8 @@ class DatabaseLogic:
 
         next_token = None
         if len(hits) > limit and limit < max_result_window:
-            if hits and (hits[-1].get("sort")):
-                next_token = hits[-1]["sort"][0]
+            if hits and (hits[limit - 1].get("sort")):
+                next_token = hits[limit - 1]["sort"][0]
 
         return collections, next_token, hit_tokens
 
@@ -793,8 +793,8 @@ class DatabaseLogic:
 
         next_token = None
         if len(hits) > limit and limit < max_result_window:
-            if hits and (hits[-1].get("sort")):
-                next_token = hits[-1]["sort"][0]
+            if hits and (hits[limit - 1].get("sort")):
+                next_token = hits[limit - 1]["sort"][0]
 
         return collections, next_token, hit_tokens
 
@@ -957,8 +957,8 @@ class DatabaseLogic:
 
         next_token = None
         if len(hits) > limit and limit < max_result_window:
-            if hits and (hits[-1].get("sort")):
-                next_token = hits[-1]["sort"][0]
+            if hits and (hits[limit - 1].get("sort")):
+                next_token = hits[limit - 1]["sort"][0]
 
         return catalogs, next_token, hit_tokens
 
@@ -1032,8 +1032,8 @@ class DatabaseLogic:
 
         next_token = None
         if len(hits) > limit and limit < max_result_window:
-            if hits and (hits[-1].get("sort")):
-                next_token = hits[-1]["sort"][0]
+            if hits and (hits[limit - 1].get("sort")):
+                next_token = hits[limit - 1]["sort"][0]
 
         return catalogs, next_token
 

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
@@ -22,11 +22,7 @@ from stac_fastapi.elasticsearch.config import AsyncElasticsearchSettings
 from stac_fastapi.elasticsearch.config import (
     ElasticsearchSettings as SyncElasticsearchSettings,
 )
-from stac_fastapi.types.errors import (
-    ConflictError,
-    InvalidQueryParameter,
-    NotFoundError,
-)
+from stac_fastapi.types.errors import ConflictError, NotFoundError
 from stac_fastapi.types.stac import Catalog, Collection, Item
 
 logger = logging.getLogger(__name__)
@@ -2479,7 +2475,6 @@ class DatabaseLogic:
 
             # Construct new sub-catalog path
             new_sub_catalog_path = f"{new_catalog_path}/{sub_catalog_id}"
-            new_sub_catalog_path_list = new_sub_catalog_path.split("/")
 
             # Calculate sub-catalog path for found catalog
             sub_catalog_path = hit["_index"].split("_", 1)[1]
@@ -2487,8 +2482,6 @@ class DatabaseLogic:
             sub_catalog_path_list.reverse()
             sub_catalog_path_list.append(sub_catalog_id)
             sub_catalog_path = "/".join(sub_catalog_path_list)
-
-            # assert f"{catalog_path}/{sub_catalog_id}" == sub_catalog_path
 
             # This is the current index for this catalog
             source_index = index_catalogs_by_catalog_id(
@@ -2552,7 +2545,7 @@ class DatabaseLogic:
             )
             collection_ids = [hit["_id"] for hit in response["hits"]["hits"]]
 
-            results = await asyncio.gather(
+            await asyncio.gather(
                 *[
                     self.client.reindex(
                         body={
@@ -2654,7 +2647,7 @@ class DatabaseLogic:
                 )
                 dest_indices_list.append(dest_index)
 
-            results = await asyncio.gather(
+            await asyncio.gather(
                 *[
                     self.client.reindex(
                         body={
@@ -2688,7 +2681,7 @@ class DatabaseLogic:
                 refresh=refresh,
             )
 
-            results = await asyncio.gather(
+            await asyncio.gather(
                 *[
                     self.reindex_sub_catalogs(
                         catalog_path=old_sub_catalog_path,
@@ -2740,7 +2733,7 @@ class DatabaseLogic:
                 )
                 collection_ids = [hit["_id"] for hit in response["hits"]["hits"]]
 
-                results = await asyncio.gather(
+                await asyncio.gather(
                     *[
                         self.client.reindex(
                             body={
@@ -2824,7 +2817,7 @@ class DatabaseLogic:
                 body={"sort": [{"id": {"order": "asc"}}]},
             )
             # Delete each catalog recursively
-            results = await asyncio.gather(
+            await asyncio.gather(
                 *[
                     self.delete_catalog(catalog_path=f"{catalog_path}/{hit['_id']}")
                     for hit in response["hits"]["hits"]
@@ -2844,7 +2837,7 @@ class DatabaseLogic:
                 body={"sort": [{"id": {"order": "asc"}}]},
             )
             collection_ids = [hit["_id"] for hit in response["hits"]["hits"]]
-            results = await asyncio.gather(
+            await asyncio.gather(
                 *[
                     delete_item_index(
                         collection_id=collection_id, catalog_path_list=catalog_path_list
@@ -2897,8 +2890,6 @@ class DatabaseLogic:
         # Create list of nested catalog ids
         catalog_path_list = catalog_path.split("/")
 
-        catalog_id = catalog_path_list[-1]
-
         await helpers.async_bulk(
             self.client,
             mk_actions(
@@ -2935,8 +2926,6 @@ class DatabaseLogic:
 
         # Create list of nested catalog ids
         catalog_path_list = catalog_path.split("/")
-
-        catalog_id = catalog_path_list[-1]
 
         helpers.bulk(
             self.sync_client,

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
@@ -682,11 +682,15 @@ class DatabaseLogic:
         if token:
             search_after = [token]
 
+        max_result_window = stac_fastapi.types.search.Limit.le
+
+        size_limit = min(limit + 1, max_result_window)
+
         response = await self.client.search(
             index=f"{COLLECTIONS_INDEX_PREFIX}*",
             body={
                 "sort": [{"id": {"order": "asc"}}],
-                "size": limit,
+                "size": size_limit,
                 "search_after": search_after,
             },
         )
@@ -707,8 +711,9 @@ class DatabaseLogic:
             )
 
         next_token = None
-        if len(hits) == limit:
-            next_token = hits[-1]["sort"][0]
+        if len(hits) > limit and limit < max_result_window:
+            if hits and (sort_array := hits[limit - 1].get("sort")):
+                next_token = hits[-1]["sort"][0]
 
         return collections, next_token
 
@@ -734,6 +739,10 @@ class DatabaseLogic:
         if token:
             search_after = [token]
 
+        # Logic to ensure next token only returned when further results are available
+        max_result_window = stac_fastapi.types.search.Limit.le
+        size_limit = min(limit + 1, max_result_window)
+
         await self.check_catalog_exists(catalog_path_list=catalog_path_list)
 
         index_param = collection_indices(catalog_paths=[catalog_path_list])
@@ -743,7 +752,7 @@ class DatabaseLogic:
                 index=index_param,
                 body={
                     "sort": [{"id": {"order": "asc"}}],
-                    "size": limit,
+                    "size": size_limit,
                     "search_after": search_after,
                 },
             )
@@ -769,8 +778,9 @@ class DatabaseLogic:
                 )
 
         next_token = None
-        if hits and len(hits) == limit:
-            next_token = hits[-1]["sort"][0]
+        if len(hits) > limit and limit < max_result_window:
+            if hits and (sort_array := hits[limit - 1].get("sort")):
+                next_token = hits[-1]["sort"][0]
 
         return collections, next_token
 
@@ -808,13 +818,17 @@ class DatabaseLogic:
         if token:
             search_after = [token]
 
+        # Logic to ensure next token only returned when further results are available
+        max_result_window = stac_fastapi.types.search.Limit.le
+        size_limit = min(limit + 1, max_result_window)
+
         # Get all contained catalogs
         try:
             response = await self.client.search(
                 index=params_index,
                 body={
                     "sort": [{"id": {"order": "asc"}}],
-                    "size": limit,
+                    "size": size_limit,
                     "search_after": search_after,
                 },
             )
@@ -922,8 +936,9 @@ class DatabaseLogic:
             )
 
         next_token = None
-        if len(hits) == limit:
-            next_token = hits[-1]["sort"][0]
+        if len(hits) > limit and limit < max_result_window:
+            if hits and (sort_array := hits[limit - 1].get("sort")):
+                next_token = hits[-1]["sort"][0]
 
         return catalogs, next_token
 
@@ -966,12 +981,16 @@ class DatabaseLogic:
         if token:
             search_after = [token]
 
+        # Logic to ensure next token only returned when further results are available
+        max_result_window = stac_fastapi.types.search.Limit.le
+        size_limit = min(limit + 1, max_result_window)
+
         try:
             response = await self.client.search(
                 index=index_param,
                 body={
                     # "sort": [{"id": {"order": "asc"}}],
-                    "size": limit,
+                    "size": size_limit,
                     "search_after": search_after,
                 },
             )
@@ -992,8 +1011,9 @@ class DatabaseLogic:
             ]
 
         next_token = None
-        if hits and len(hits) == limit:
-            next_token = hits[-1]["sort"][0]
+        if len(hits) > limit and limit < max_result_window:
+            if hits and (sort_array := hits[limit - 1].get("sort")):
+                next_token = hits[-1]["sort"][0]
 
         return catalogs, next_token
 


### PR DESCRIPTION
## Add Access Control to Catalogue Entries
- Access control for entries is determined from hash indices for each user, currently we limit this to 1024 entries, as this seems sufficient from early testing, but expect this will be increased in future.
  - Note, the final index is reserved as the `public` index
- Added access_control code to generate hash indexes for users
  - These are stored in elasticsearch and used to determine whether a user has access to a specific entry
  - Bitstrings defining user access are recorded for each catalog and collection
  - Parent catalogs are assigned bitstrings as bitwise OR of all their children bitstrings
- Results from elasticsearch are filtered to only display those entries that are accessible to the current user
  - This includes child data for parent catalogs
- User authorisation is extracted from the `Authorization` header of the incoming request, decoded as a jwt token
  - This is passed from the OAuth2 proxy into stac-fastapi
  - STAC-FastApi is only concerned with the `preferred_username` value
- Entries can be created as private or public using an `is_public` parameter
- The workspace is used when creating, updating or deleting entries to determine whether the correct access is provided to make such changes to the catalogue
  - `default_workpace` has admin privilege and can create entries anywhere, `user-workspace` can only edit entries in the `user-datasets/user-workspace` sub-catalog  
  - The access control for the created entries is determined from the `is_public`, `workspace` and `catalog_path` provided in the request
    - If `is_public` is `False`, `workspace` is `default_workspace`  and catalog path starts `user-datasets/` it is assumed this catalog will only be available to the username defined in the path e.g. `user-datasets/<workspace-name>` will only be visible to the user `workspace-name` for the time being. 
    - If the path doesn't define a `workspace-name` instead the catalog_id of the catalog to be ingested will be used. E.g. when ingesting a catalog with id `workspace-name` this will only be accessible to the user with the same `workspace-name` username.
    - For collections, access control is determined from the parent catalog under `user-datasets` otherwise an exception is raised.

### Other changes
- Some minor code fixes to improve formatting