### PR TITLE
Add next token to execute_search call under post_search

### DIFF
--- a/stac_fastapi/core/stac_fastapi/core/core.py
+++ b/stac_fastapi/core/stac_fastapi/core/core.py
@@ -996,7 +996,7 @@ class CoreClient(AsyncBaseCoreClient):
         items, maybe_count, next_token = await self.database.execute_search(
             search=search,
             limit=limit,
-            token=None,  # search_request.token,  # type: ignore
+            token=search_request.token,  # type: ignore
             sort=sort,
             collection_ids=search_request.collections,
             catalog_paths=[catalog_path],


### PR DESCRIPTION
## Bugfix for Next Token Functionality
Added token from the search request into the call to `execute_search` for POST `/search` calls