### PR TITLE
Bugfix/eodhp 549 fastapi ensure next link only included when subsequent results exist

### DIFF
--- a/stac_fastapi/core/stac_fastapi/core/core.py
+++ b/stac_fastapi/core/stac_fastapi/core/core.py
@@ -273,11 +273,15 @@ class CoreClient(AsyncBaseCoreClient):
         collections = []
 
         while True:
-            temp_collections, next_token, hit_tokens = await self.database.get_all_collections(
-                token=token, limit=limit, base_url=base_url
+            temp_collections, next_token, hit_tokens = (
+                await self.database.get_all_collections(
+                    token=token, limit=limit, base_url=base_url
+                )
             )
 
-            for i, (collection, hit_token) in enumerate(zip(temp_collections, hit_tokens)):
+            for i, (collection, hit_token) in enumerate(
+                zip(temp_collections, hit_tokens)
+            ):
                 # Get access control array for each collection
                 access_control = collection["access_control"]
                 collection.pop("access_control")
@@ -341,13 +345,15 @@ class CoreClient(AsyncBaseCoreClient):
 
         while True:
             # Search is run continually until limit is reached or no more results
-            temp_catalogs, next_token, hit_tokens = await self.database.get_all_catalogs(
-                catalog_path=catalog_path,
-                token=token,
-                limit=limit,
-                base_url=base_url,
-                user_index=user_index,
-                conformance_classes=self.conformance_classes(),
+            temp_catalogs, next_token, hit_tokens = (
+                await self.database.get_all_catalogs(
+                    catalog_path=catalog_path,
+                    token=token,
+                    limit=limit,
+                    base_url=base_url,
+                    user_index=user_index,
+                    conformance_classes=self.conformance_classes(),
+                )
             )
 
             for i, (catalog, hit_token) in enumerate(zip(temp_catalogs, hit_tokens)):
@@ -470,7 +476,7 @@ class CoreClient(AsyncBaseCoreClient):
             )
 
         # Assume at most 100 collections in a catalog for the time being, may need to increase
-        collections, _, _= await self.database.get_catalog_collections(
+        collections, _, _ = await self.database.get_catalog_collections(
             catalog_path=catalog_path,
             base_url=base_url,
             limit=NUMBER_OF_CATALOG_COLLECTIONS,
@@ -565,15 +571,19 @@ class CoreClient(AsyncBaseCoreClient):
         collections = []
 
         while True:
-            temp_collections, next_token, hit_tokens = await self.database.get_catalog_collections(
-                catalog_path=catalog_path,
-                token=token,  # type: ignore
-                limit=limit,
-                base_url=base_url,
+            temp_collections, next_token, hit_tokens = (
+                await self.database.get_catalog_collections(
+                    catalog_path=catalog_path,
+                    token=token,  # type: ignore
+                    limit=limit,
+                    base_url=base_url,
+                )
             )
 
             # Check if current user has access to each collection
-            for i, (collection, hit_token) in enumerate(zip(temp_collections, hit_tokens)):
+            for i, (collection, hit_token) in enumerate(
+                zip(temp_collections, hit_tokens)
+            ):
                 # Get access control array for each collection
                 access_control = collection["access_control"]
                 collection.pop("access_control")
@@ -1054,13 +1064,15 @@ class CoreClient(AsyncBaseCoreClient):
         items = []
 
         while True:
-            temp_items, maybe_count, next_token, hit_tokens = await self.database.execute_search(
-                search=search,
-                limit=limit,
-                token=token,  # type: ignore
-                sort=sort,
-                collection_ids=search_request.collections,
-                catalog_paths=search_request.catalog_paths,
+            temp_items, maybe_count, next_token, hit_tokens = (
+                await self.database.execute_search(
+                    search=search,
+                    limit=limit,
+                    token=token,  # type: ignore
+                    sort=sort,
+                    collection_ids=search_request.collections,
+                    catalog_paths=search_request.catalog_paths,
+                )
             )
 
             # Filter results to those that are accessible to the user
@@ -1106,7 +1118,6 @@ class CoreClient(AsyncBaseCoreClient):
                 # TODO: implement smarter token logic to return token of last returned ES entry
                 break
             token = next_token
-
 
         # To handle catalog_id in links execute_search also returns the catalog_id
         # from search results in a tuple
@@ -1391,13 +1402,15 @@ class CoreClient(AsyncBaseCoreClient):
         items = []
 
         while True:
-            temp_items, maybe_count, next_token, hit_tokens = await self.database.execute_search(
-                search=search,
-                limit=limit,
-                token=token,  # type: ignore
-                sort=sort,
-                collection_ids=collections,
-                catalog_paths=[catalog_path],
+            temp_items, maybe_count, next_token, hit_tokens = (
+                await self.database.execute_search(
+                    search=search,
+                    limit=limit,
+                    token=token,  # type: ignore
+                    sort=sort,
+                    collection_ids=collections,
+                    catalog_paths=[catalog_path],
+                )
             )
 
             # Filter results to those that are accessible to the user
@@ -2290,7 +2303,9 @@ class EsAsyncCollectionSearchClient(AsyncCollectionSearchClient):
             )
 
             # Filter results to those that are accessible to the user
-            for i, (collection, hit_token) in enumerate(zip(temp_collections, hit_tokens)):
+            for i, (collection, hit_token) in enumerate(
+                zip(temp_collections, hit_tokens)
+            ):
                 # Get access control array for this collection
                 access_control = collection["access_control"]
                 collection.pop("access_control")
@@ -2452,7 +2467,9 @@ class EsAsyncDiscoverySearchClient(AsyncDiscoverySearchClient):
             )
 
             # Filter results to those that are accessible to the user
-            for i, (data, hit_token) in enumerate(zip(temp_catalogs_and_collections, hit_tokens)):
+            for i, (data, hit_token) in enumerate(
+                zip(temp_catalogs_and_collections, hit_tokens)
+            ):
                 # Get access control array for this collection
                 access_control = data["access_control"]
                 data.pop("access_control")

--- a/stac_fastapi/core/stac_fastapi/core/core.py
+++ b/stac_fastapi/core/stac_fastapi/core/core.py
@@ -357,13 +357,8 @@ class CoreClient(AsyncBaseCoreClient):
                 # Add catalog to list if user has access
                 if int(access_control[-1]) or int(access_control[user_index]):
                     catalogs.append(catalog)
-                    print("catalogs length is ", len(catalogs))
-                    print("limit is ", limit)
                     if len(catalogs) >= limit:
-                        print("here")
-                        print(i)
                         if i < len(temp_catalogs) - 1:
-                            print("AND FINALLY HERE")
                             # Extract token from last result
                             next_token = hit_token
                             break
@@ -1283,7 +1278,6 @@ class CoreClient(AsyncBaseCoreClient):
         username_header: dict,
         **kwargs,
     ) -> ItemCollection:
-        print("post search")
         """
         Perform a POST search on a specific sub-catalog.
 

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
@@ -711,8 +711,8 @@ class DatabaseLogic:
                 )
             )
             if hit.get("sort"):
-                    hit_token = hit["sort"][0]
-                    hit_tokens.append(hit_token)
+                hit_token = hit["sort"][0]
+                hit_tokens.append(hit_token)
             else:
                 hit_tokens.append(None)
 
@@ -950,8 +950,8 @@ class DatabaseLogic:
                 )
             )
             if hit.get("sort"):
-                    hit_token = hit["sort"][0]
-                    hit_tokens.append(hit_token)
+                hit_token = hit["sort"][0]
+                hit_tokens.append(hit_token)
             else:
                 hit_tokens.append(None)
 
@@ -3185,9 +3185,7 @@ class DatabaseLogic:
 
         hit_tokens = []
         for i, hit in enumerate(catalog_hits):
-            catalog_index_list = (
-                hit["_index"].split("_", 1)[1].split(CATALOG_SEPARATOR)
-            )
+            catalog_index_list = hit["_index"].split("_", 1)[1].split(CATALOG_SEPARATOR)
             catalog_index_list.reverse()
             catalog_index = "/".join(catalog_index_list)
             sub_data_catalogs_and_collections = child_data[i]

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
@@ -718,8 +718,8 @@ class DatabaseLogic:
 
         next_token = None
         if len(hits) > limit and limit < max_result_window:
-            if hits and (hits[-1].get("sort")):
-                next_token = hits[-1]["sort"][0]
+            if hits and (hits[limit - 1].get("sort")):
+                next_token = hits[limit - 1]["sort"][0]
 
         return collections, next_token, hit_tokens
 
@@ -793,8 +793,8 @@ class DatabaseLogic:
 
         next_token = None
         if len(hits) > limit and limit < max_result_window:
-            if hits and (hits[-1].get("sort")):
-                next_token = hits[-1]["sort"][0]
+            if hits and (hits[limit - 1].get("sort")):
+                next_token = hits[limit - 1]["sort"][0]
 
         return collections, next_token, hit_tokens
 
@@ -957,8 +957,8 @@ class DatabaseLogic:
 
         next_token = None
         if len(hits) > limit and limit < max_result_window:
-            if hits and (hits[-1].get("sort")):
-                next_token = hits[-1]["sort"][0]
+            if hits and (hits[limit - 1].get("sort")):
+                next_token = hits[limit - 1]["sort"][0]
 
         return catalogs, next_token, hit_tokens
 
@@ -1032,8 +1032,8 @@ class DatabaseLogic:
 
         next_token = None
         if len(hits) > limit and limit < max_result_window:
-            if hits and (hits[-1].get("sort")):
-                next_token = hits[-1]["sort"][0]
+            if hits and (hits[limit - 1].get("sort")):
+                next_token = hits[limit - 1]["sort"][0]
 
         return catalogs, next_token
 

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
@@ -682,11 +682,15 @@ class DatabaseLogic:
         if token:
             search_after = [token]
 
+        max_result_window = stac_fastapi.types.search.Limit.le
+
+        size_limit = min(limit + 1, max_result_window)
+
         response = await self.client.search(
             index=f"{COLLECTIONS_INDEX_PREFIX}*",
             body={
                 "sort": [{"id": {"order": "asc"}}],
-                "size": limit,
+                "size": size_limit,
                 "search_after": search_after,
             },
         )
@@ -707,8 +711,9 @@ class DatabaseLogic:
             )
 
         next_token = None
-        if len(hits) == limit:
-            next_token = hits[-1]["sort"][0]
+        if len(hits) > limit and limit < max_result_window:
+            if hits and (sort_array := hits[limit - 1].get("sort")):
+                next_token = hits[-1]["sort"][0]
 
         return collections, next_token
 
@@ -734,6 +739,10 @@ class DatabaseLogic:
         if token:
             search_after = [token]
 
+        # Logic to ensure next token only returned when further results are available
+        max_result_window = stac_fastapi.types.search.Limit.le
+        size_limit = min(limit + 1, max_result_window)
+
         await self.check_catalog_exists(catalog_path_list=catalog_path_list)
 
         index_param = collection_indices(catalog_paths=[catalog_path_list])
@@ -743,7 +752,7 @@ class DatabaseLogic:
                 index=index_param,
                 body={
                     "sort": [{"id": {"order": "asc"}}],
-                    "size": limit,
+                    "size": size_limit,
                     "search_after": search_after,
                 },
             )
@@ -769,8 +778,9 @@ class DatabaseLogic:
                 )
 
         next_token = None
-        if hits and len(hits) == limit:
-            next_token = hits[-1]["sort"][0]
+        if len(hits) > limit and limit < max_result_window:
+            if hits and (sort_array := hits[limit - 1].get("sort")):
+                next_token = hits[-1]["sort"][0]
 
         return collections, next_token
 
@@ -808,13 +818,17 @@ class DatabaseLogic:
         if token:
             search_after = [token]
 
+        # Logic to ensure next token only returned when further results are available
+        max_result_window = stac_fastapi.types.search.Limit.le
+        size_limit = min(limit + 1, max_result_window)
+
         # Get all contained catalogs
         try:
             response = await self.client.search(
                 index=params_index,
                 body={
                     "sort": [{"id": {"order": "asc"}}],
-                    "size": limit,
+                    "size": size_limit,
                     "search_after": search_after,
                 },
             )
@@ -922,8 +936,9 @@ class DatabaseLogic:
             )
 
         next_token = None
-        if len(hits) == limit:
-            next_token = hits[-1]["sort"][0]
+        if len(hits) > limit and limit < max_result_window:
+            if hits and (sort_array := hits[limit - 1].get("sort")):
+                next_token = hits[-1]["sort"][0]
 
         return catalogs, next_token
 
@@ -966,12 +981,16 @@ class DatabaseLogic:
         if token:
             search_after = [token]
 
+        # Logic to ensure next token only returned when further results are available
+        max_result_window = stac_fastapi.types.search.Limit.le
+        size_limit = min(limit + 1, max_result_window)
+
         try:
             response = await self.client.search(
                 index=index_param,
                 body={
                     # "sort": [{"id": {"order": "asc"}}],
-                    "size": limit,
+                    "size": size_limit,
                     "search_after": search_after,
                 },
             )
@@ -992,8 +1011,9 @@ class DatabaseLogic:
             ]
 
         next_token = None
-        if hits and len(hits) == limit:
-            next_token = hits[-1]["sort"][0]
+        if len(hits) > limit and limit < max_result_window:
+            if hits and (sort_array := hits[limit - 1].get("sort")):
+                next_token = hits[-1]["sort"][0]
 
         return catalogs, next_token
 


### PR DESCRIPTION
## Update STAC-FastApi to Only Return Tokens for Pagination when Subsequent Results are Available
- Update token logic to only return token when mroe results are available in elasticsearch
  - Logic borrows from a [later commit](https://github.com/stac-utils/stac-fastapi-elasticsearch-opensearch/pull/243) to the STAC-FastApi repository
- Updated token handling for access-control to return the token for the last result returned to allow pagination to continue based on last accessible result, rather than last ES response
  - The tokens for each ES result are returned from certain functions to allow STAC-FastApi to return the token for the last result returned after the access-control layer has filtered the responses
  - This allows pagination to continue from the latest access-controlled entry, rather than from the latest ES token


This PR is to be merged into the EODHP-481 branch as this also includes updates to pagination logic and this helps to consolidate code changes together.