### PR TITLE
Patch/eodhp 921 limit collections to only current catalog

### DIFF
--- a/stac_fastapi/core/stac_fastapi/core/core.py
+++ b/stac_fastapi/core/stac_fastapi/core/core.py
@@ -58,8 +58,8 @@ from stac_fastapi.types.search import (
     Limit,
 )
 from stac_fastapi.types.stac import (
-    Catalogs,
     Catalog,
+    Catalogs,
     CatalogsAndCollections,
     Collection,
     Collections,

--- a/stac_fastapi/core/stac_fastapi/core/core.py
+++ b/stac_fastapi/core/stac_fastapi/core/core.py
@@ -5,6 +5,7 @@ import os
 import re
 from datetime import datetime as datetime_type
 from datetime import timezone
+from distutils.util import strtobool
 from typing import Any, Dict, List, Optional, Set, Type, Union
 from urllib.parse import unquote_plus, urljoin
 
@@ -2339,6 +2340,7 @@ class EsAsyncCollectionSearchClient(AsyncCollectionSearchClient):
         base_url = str(request.base_url)
         token = request.query_params.get("token")
         limit = int(request.query_params.get("limit", 10))
+        glob = strtobool(request.query_params.get("glob", False))
 
         # Extract X-Username header from username_header for access control
         username = username_header.get("X-Username", "")
@@ -2409,6 +2411,7 @@ class EsAsyncCollectionSearchClient(AsyncCollectionSearchClient):
                     base_url=base_url,
                     token=token,
                     sort=sort,
+                    glob=glob,
                     catalog_path=catalog_path,
                 )
             )
@@ -2451,6 +2454,7 @@ class EsAsyncCollectionSearchClient(AsyncCollectionSearchClient):
         datetime: Optional[Union[str, datetime_type]] = None,
         limit: Optional[int] = 10,
         q: Optional[List[str]] = None,
+        glob: Optional[bool] = False,
         **kwargs,
     ) -> Collections:
         """Get search results from the database for collections.
@@ -2480,6 +2484,7 @@ class EsAsyncCollectionSearchClient(AsyncCollectionSearchClient):
             "bbox": bbox,
             "datetime": datetime,
             "q": q,
+            "glob": glob,
         }
 
         # Do the request

--- a/stac_fastapi/core/stac_fastapi/core/core.py
+++ b/stac_fastapi/core/stac_fastapi/core/core.py
@@ -2340,7 +2340,7 @@ class EsAsyncCollectionSearchClient(AsyncCollectionSearchClient):
         base_url = str(request.base_url)
         token = request.query_params.get("token")
         limit = int(request.query_params.get("limit", 10))
-        glob = strtobool(request.query_params.get("glob", False))
+        glob = strtobool(request.query_params.get("glob", "false"))
 
         # Extract X-Username header from username_header for access control
         username = username_header.get("X-Username", "")

--- a/stac_fastapi/core/stac_fastapi/core/types/core.py
+++ b/stac_fastapi/core/stac_fastapi/core/types/core.py
@@ -482,6 +482,7 @@ class AsyncCollectionSearchClient(abc.ABC):
         datetime: Optional[Union[str, datetime]] = None,
         limit: Optional[int] = 10,
         q: Optional[List[str]] = None,
+        glob: Optional[bool] = False,
         **kwargs,
     ) -> stac_types.Collections:
         """Cross catalog search (GET) for collections.

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
@@ -1583,6 +1583,7 @@ class DatabaseLogic:
         base_url: str,
         token: Optional[str],
         sort: Optional[Dict[str, Dict[str, str]]],
+        glob: Optional[bool] = False,
         catalog_path: str = None,
         ignore_unavailable: bool = True,
     ) -> Tuple[Iterable[Dict[str, Any]], Optional[int], Optional[str]]:
@@ -1619,10 +1620,16 @@ class DatabaseLogic:
         if catalog_path:
             catalog_path_list = catalog_path.split("/")
             catalog_index = index_collections_by_catalog_id(catalog_path_list)
-            # catalog_index = catalog_index.replace("collections_", "collections_*")
+            if glob:
+                logger.info("Performing global collections search")
+                catalog_index = catalog_index.replace("collections_", "collections_*") # Search all collections
         else:
-            # catalog_index = f"{COLLECTIONS_INDEX_PREFIX}*"
-            return [], 0, None, []
+            if glob:
+                logger.info("Performing global collections search")
+                catalog_index = f"{COLLECTIONS_INDEX_PREFIX}*"  # Search all collections
+            else:
+                return [], 0, None, [] # No collections at top level
+            
 
         # Logic to ensure next token only returned when further results are available
         max_result_window = stac_fastapi.types.search.Limit.le

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
@@ -325,7 +325,8 @@ def index_catalogs_by_catalog_id(catalog_path_list: Optional[List[str]] = None) 
         new_catalog_path_list.reverse()
         return f"{CATALOGS_INDEX_PREFIX}{CATALOG_SEPARATOR.join(''.join(c for c in catalog_id.lower() if c not in ES_INDEX_NAME_UNSUPPORTED_CHARS) for catalog_id in new_catalog_path_list)}"
     # Potentially may only want top-level catalogs, so need to add BASE to index here
-    return f"{CATALOGS_INDEX_PREFIX}*"
+    # return f"{CATALOGS_INDEX_PREFIX}*"
+    return ROOT_CATALOGS_INDEX
 
 
 def indices(

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
@@ -1619,7 +1619,7 @@ class DatabaseLogic:
         if catalog_path:
             catalog_path_list = catalog_path.split("/")
             catalog_index = index_collections_by_catalog_id(catalog_path_list)
-            catalog_index = catalog_index.replace("collections_", "collections_*")
+            # catalog_index = catalog_index.replace("collections_", "collections_*")
         else:
             catalog_index = f"{COLLECTIONS_INDEX_PREFIX}*"
 

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
@@ -1622,14 +1622,15 @@ class DatabaseLogic:
             catalog_index = index_collections_by_catalog_id(catalog_path_list)
             if glob:
                 logger.info("Performing global collections search")
-                catalog_index = catalog_index.replace("collections_", "collections_*") # Search all collections
+                catalog_index = catalog_index.replace(
+                    "collections_", "collections_*"
+                )  # Search all collections
         else:
             if glob:
                 logger.info("Performing global collections search")
                 catalog_index = f"{COLLECTIONS_INDEX_PREFIX}*"  # Search all collections
             else:
-                return [], 0, None, [] # No collections at top level
-            
+                return [], 0, None, []  # No collections at top level
 
         # Logic to ensure next token only returned when further results are available
         max_result_window = stac_fastapi.types.search.Limit.le

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
@@ -1621,7 +1621,8 @@ class DatabaseLogic:
             catalog_index = index_collections_by_catalog_id(catalog_path_list)
             # catalog_index = catalog_index.replace("collections_", "collections_*")
         else:
-            catalog_index = f"{COLLECTIONS_INDEX_PREFIX}*"
+            # catalog_index = f"{COLLECTIONS_INDEX_PREFIX}*"
+            return [], 0, None, None
 
         # Logic to ensure next token only returned when further results are available
         max_result_window = stac_fastapi.types.search.Limit.le

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
@@ -1622,7 +1622,7 @@ class DatabaseLogic:
             # catalog_index = catalog_index.replace("collections_", "collections_*")
         else:
             # catalog_index = f"{COLLECTIONS_INDEX_PREFIX}*"
-            return [], 0, None, None
+            return [], 0, None, []
 
         # Logic to ensure next token only returned when further results are available
         max_result_window = stac_fastapi.types.search.Limit.le


### PR DESCRIPTION
## Minor update to /collections
- Ensure that the `/collections` endpoint only returns collections under the specified catalog and not ALL collections at or below this level.
- Updated indexing to remove wildcards and only use the specified catalog when identifying sub-collections
- Returns an empty list when no catalog path is provided as no collections can be added at the root catalog