### PR TITLE
Update wildcard usage when searching collections index

### DIFF
--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
@@ -1619,7 +1619,7 @@ class DatabaseLogic:
         if catalog_path:
             catalog_path_list = catalog_path.split("/")
             catalog_index = index_collections_by_catalog_id(catalog_path_list)
-            catalog_index = catalog_index.replace("collections_", "collections_*")
+            catalog_index = catalog_index.replace("collections_", "collections*_")
         else:
             catalog_index = f"{COLLECTIONS_INDEX_PREFIX}*"
 


### PR DESCRIPTION
## Bugfix to Address Wrong Collections Indexing
- Previous wildcard usage in the collections-search code meant collections in other catalogs that end in the same string as the desired catalog will also be returned
- For example: 
  - If there are two catalogs: `airbus` and `test-airbus` their contained collections will be indexed in the indices `collections_airbus` and `collections_test-airbus` respectively
  - Then if we wish to return all the collections in the `airbus` catalog, we can search the index `collections_airbus`. 
  - However, as we want to also see any collections that sit below this catalog, we use a wildcard to carry out this search, looking at the index `collections_*airbus`. 
  - However this wildcard usage means **both** of the above indices are included, which is not what we want.
  - Instead, using the wildcard value like this `collections*_airbus` ensures that only collections that sit within the `airbus` catalog or subcatalogs will be returned, as `collections_test-airbus` does not match the regex.
  - Any subcatalogs also match this regex, e.g. the `sub-catalog` catalog: `collections_sub-catalog____airbus`