### PR TITLE
Update delete catalog function to remove indices with wildcards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## EODHP
 The following changes have been made for the EODHP project
 
+### v0.3.12 - 2024-11-01
+Bugfix - remove collection and item indexes when catalog is removed
+
+
 ### v0.3.11 - 2024-10-07
 Bugfix - handle entries with missing access control, sometimes seen during debugging
 


### PR DESCRIPTION
## Delete Catalog Function should remove Indices from Elasticsearch
- Rather than searching for all subcatalogs and collections in a given catalog, we can simply remove all indices that include the specified catalog using wildcards
- So removing catalog `catalog_1/catalog_2` we can remove the indices that relate to catalogs, collection and items sitting within this catalog:
  - `catalogs*_catalog_1____catalog_2`
  - `collections*_catalog_1____catalog_2`
  - `items_*_xx_catalog_1____catalog2` (the `_xx_` represents the group separator splitting catalog ids from collection ids)
