### PR TITLE
Bugfix/eodhp 1018 incorrect catalogs collections links

### DIFF
--- a/stac_fastapi/core/stac_fastapi/core/core.py
+++ b/stac_fastapi/core/stac_fastapi/core/core.py
@@ -507,13 +507,26 @@ class CoreClient(AsyncBaseCoreClient):
                 break
             token = next_token
 
+        if catalog_path:
+            catalog_url = f"catalogs/{catalog_path}"
+        else:
+            catalog_url = ""
+
         links = [
-            {"rel": Relations.root.value, "type": MimeTypes.json, "href": base_url},
-            {"rel": Relations.parent.value, "type": MimeTypes.json, "href": base_url},
+            {
+                "rel": Relations.root.value,
+                "type": MimeTypes.json,
+                "href": urljoin(base_url, catalog_url),
+            },
+            {
+                "rel": Relations.parent.value,
+                "type": MimeTypes.json,
+                "href": urljoin(base_url, catalog_url),
+            },
             {
                 "rel": Relations.self.value,
                 "type": MimeTypes.json,
-                "href": urljoin(base_url, "catalogs"),
+                "href": f"{urljoin(base_url, catalog_url)}catalogs",
             },
         ]
 
@@ -2587,9 +2600,32 @@ class EsAsyncCollectionSearchClient(AsyncCollectionSearchClient):
                 break
             token = next_token
 
-        links = []
+        if catalog_path:
+            catalog_url = f"catalogs/{catalog_path}"
+        else:
+            catalog_url = ""
+
+        links = [
+            {
+                "rel": Relations.root.value,
+                "type": MimeTypes.json,
+                "href": urljoin(base_url, catalog_url),
+            },
+            {
+                "rel": Relations.parent.value,
+                "type": MimeTypes.json,
+                "href": urljoin(base_url, catalog_url),
+            },
+            {
+                "rel": Relations.self.value,
+                "type": MimeTypes.json,
+                "href": f"{urljoin(base_url, catalog_url)}collections",
+            },
+        ]
+
         if next_token:
-            links = await PagingLinks(request=request, next=next_token).get_links()
+            next_link = PagingLinks(next=next_token, request=request).link_next()
+            links.append(next_link)
 
         return Collections(collections=collections, links=links)
 

--- a/stac_fastapi/core/stac_fastapi/core/core.py
+++ b/stac_fastapi/core/stac_fastapi/core/core.py
@@ -526,7 +526,7 @@ class CoreClient(AsyncBaseCoreClient):
             {
                 "rel": Relations.self.value,
                 "type": MimeTypes.json,
-                "href": f"{urljoin(base_url, catalog_url)}catalogs",
+                "href": f"{urljoin(base_url, catalog_url)}/catalogs",
             },
         ]
 
@@ -2619,7 +2619,7 @@ class EsAsyncCollectionSearchClient(AsyncCollectionSearchClient):
             {
                 "rel": Relations.self.value,
                 "type": MimeTypes.json,
-                "href": f"{urljoin(base_url, catalog_url)}collections",
+                "href": f"{urljoin(base_url, catalog_url)}/collections",
             },
         ]
 

--- a/stac_fastapi/core/stac_fastapi/core/core.py
+++ b/stac_fastapi/core/stac_fastapi/core/core.py
@@ -516,7 +516,7 @@ class CoreClient(AsyncBaseCoreClient):
             {
                 "rel": Relations.root.value,
                 "type": MimeTypes.json,
-                "href": urljoin(base_url, catalog_url),
+                "href": base_url,
             },
             {
                 "rel": Relations.parent.value,
@@ -2609,7 +2609,7 @@ class EsAsyncCollectionSearchClient(AsyncCollectionSearchClient):
             {
                 "rel": Relations.root.value,
                 "type": MimeTypes.json,
-                "href": urljoin(base_url, catalog_url),
+                "href": base_url,
             },
             {
                 "rel": Relations.parent.value,

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
@@ -2952,6 +2952,7 @@ class DatabaseLogic:
                 f"Catalog {catalog_id} at {'path ' + '/'.join(catalog_path_list[:-1]) if len(catalog_path_list) > 1 else 'top-level'} has no items, so index does not exist and cannot be deleted, continuing as normal."
             )
 
+
     async def bulk_async(
         self,
         catalog_path: str,

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
@@ -516,7 +516,6 @@ async def delete_item_index(collection_id: str, catalog_path_list: List[str]):
         await client.indices.delete(index=name)
     await client.close()
 
-
 async def delete_item_index_by_catalog(catalog_path_list: List[str]):
     """Delete the index for items in a collection, specifying the catalog and top-level catalog.
 
@@ -528,12 +527,8 @@ async def delete_item_index_by_catalog(catalog_path_list: List[str]):
     client = AsyncElasticsearchSettings().create_client
 
     # Index by catalog path, then replace the catalog index with the items index
-    name = index_catalogs_by_catalog_id(catalog_path_list=catalog_path_list).replace(
-        CATALOGS_INDEX_PREFIX, ITEMS_INDEX_PREFIX
-    )
-    name = name.replace(
-        "items_", f"items_*{GROUP_SEPARATOR}", 1
-    )  # ensure we are looking in collections that sit within the specified catalog
+    name = index_catalogs_by_catalog_id(catalog_path_list=catalog_path_list).replace(CATALOGS_INDEX_PREFIX, ITEMS_INDEX_PREFIX)
+    name = name.replace("items_", f"items_*{GROUP_SEPARATOR}", 1)  # ensure we are looking in collections that sit within the specified catalog
     resolved = await client.indices.resolve_index(name=name)
     if "aliases" in resolved and resolved["aliases"]:
         [alias] = resolved["aliases"]
@@ -2944,9 +2939,7 @@ class DatabaseLogic:
             )
         # Remove index for collections in this index
         try:
-            await delete_collection_index_by_catalog(
-                catalog_path_list=catalog_path_list
-            )
+            await delete_collection_index_by_catalog(catalog_path_list=catalog_path_list)
         except NotFoundError:
             logger.warning(
                 f"Catalog {catalog_id} at {'path ' + '/'.join(catalog_path_list[:-1]) if len(catalog_path_list) > 1 else 'top-level'} has no collections, so index does not exist and cannot be deleted, continuing as normal."

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
@@ -528,7 +528,7 @@ async def delete_item_index_by_catalog(catalog_path_list: List[str]):
 
     # Index by catalog path, then replace the catalog index with the items index
     name = index_catalogs_by_catalog_id(catalog_path_list=catalog_path_list).replace(CATALOGS_INDEX_PREFIX, ITEMS_INDEX_PREFIX)
-    name = name.replace("items_", f"items_*{GROUP_SEPARATOR}", 1)  # ensure we are looking in collections that sit within the specified catalog
+    name = name.replace("items_", f"items_*{GROUP_SEPARATOR}", 1) # ensure we are looking in collections that sit within the specified catalog
     resolved = await client.indices.resolve_index(name=name)
     if "aliases" in resolved and resolved["aliases"]:
         [alias] = resolved["aliases"]

--- a/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
+++ b/stac_fastapi/elasticsearch/stac_fastapi/elasticsearch/database_logic.py
@@ -516,6 +516,7 @@ async def delete_item_index(collection_id: str, catalog_path_list: List[str]):
         await client.indices.delete(index=name)
     await client.close()
 
+
 async def delete_item_index_by_catalog(catalog_path_list: List[str]):
     """Delete the index for items in a collection, specifying the catalog and top-level catalog.
 
@@ -527,8 +528,12 @@ async def delete_item_index_by_catalog(catalog_path_list: List[str]):
     client = AsyncElasticsearchSettings().create_client
 
     # Index by catalog path, then replace the catalog index with the items index
-    name = index_catalogs_by_catalog_id(catalog_path_list=catalog_path_list).replace(CATALOGS_INDEX_PREFIX, ITEMS_INDEX_PREFIX)
-    name = name.replace("items_", f"items_*{GROUP_SEPARATOR}", 1) # ensure we are looking in collections that sit within the specified catalog
+    name = index_catalogs_by_catalog_id(catalog_path_list=catalog_path_list).replace(
+        CATALOGS_INDEX_PREFIX, ITEMS_INDEX_PREFIX
+    )
+    name = name.replace(
+        "items_", f"items_*{GROUP_SEPARATOR}", 1
+    )  # ensure we are looking in collections that sit within the specified catalog
     resolved = await client.indices.resolve_index(name=name)
     if "aliases" in resolved and resolved["aliases"]:
         [alias] = resolved["aliases"]
@@ -2939,7 +2944,9 @@ class DatabaseLogic:
             )
         # Remove index for collections in this index
         try:
-            await delete_collection_index_by_catalog(catalog_path_list=catalog_path_list)
+            await delete_collection_index_by_catalog(
+                catalog_path_list=catalog_path_list
+            )
         except NotFoundError:
             logger.warning(
                 f"Catalog {catalog_id} at {'path ' + '/'.join(catalog_path_list[:-1]) if len(catalog_path_list) > 1 else 'top-level'} has no collections, so index does not exist and cannot be deleted, continuing as normal."
@@ -2951,7 +2958,6 @@ class DatabaseLogic:
             logger.warning(
                 f"Catalog {catalog_id} at {'path ' + '/'.join(catalog_path_list[:-1]) if len(catalog_path_list) > 1 else 'top-level'} has no items, so index does not exist and cannot be deleted, continuing as normal."
             )
-
 
     async def bulk_async(
         self,


### PR DESCRIPTION
## Correct Links in `/catalogs` and `/collections` endpoints for all but top-level
- Construct links based on current catalog path for:
  - parent
  - self
  - next
